### PR TITLE
fix: process-input-not-final

### DIFF
--- a/src/main/java/nva/commons/handlers/ApiGatewayHandler.java
+++ b/src/main/java/nva/commons/handlers/ApiGatewayHandler.java
@@ -130,7 +130,7 @@ public abstract class ApiGatewayHandler<I, O> implements RequestStreamHandler {
      * @throws IOException        when processing fails
      * @throws URISyntaxException when processing fails
      */
-    protected final O processInput(I input, String apiGatewayInputString, Context context) throws ApiGatewayException {
+    protected O processInput(I input, String apiGatewayInputString, Context context) throws ApiGatewayException {
         RequestInfo requestInfo = inputParser.getRequestInfo(apiGatewayInputString);
         return processInput(input, requestInfo, context);
     }


### PR DESCRIPTION
Make the processInput method that has the ApiGateway request JSON string available not final. 
Useful for debugging sometimes to override this method and log the the whole request