### PR TITLE
Failure throws original unchecked exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ wrapper {
 
 allprojects {
     group = 'com.github.bibsysdev'
-    version = '1.5.0'
+    version = '1.5.2'
 
     apply plugin: 'java-library'
     apply plugin: 'jacoco'

--- a/core/src/main/java/nva/commons/core/attempt/Failure.java
+++ b/core/src/main/java/nva/commons/core/attempt/Failure.java
@@ -44,6 +44,11 @@ public class Failure<T> extends Try<T> {
     }
 
     @Override
+    public <E extends Exception> Try<Void> forEach(ConsumerWithException<T, E> consumer) {
+        return new Failure<Void>(exception);
+    }
+
+    @Override
     public <E extends Exception> T orElseThrow(Function<Failure<T>, E> action) throws E {
         if (action != null) {
             throw action.apply(this);
@@ -54,7 +59,11 @@ public class Failure<T> extends Try<T> {
 
     @Override
     public T orElseThrow() {
-        throw new RuntimeException(this.getException());
+        if (this.getException() instanceof RuntimeException) {
+            throw (RuntimeException) this.getException();
+        } else {
+            throw new RuntimeException(this.getException());
+        }
     }
 
     @Override
@@ -75,10 +84,5 @@ public class Failure<T> extends Try<T> {
     @Override
     public Optional<T> toOptional() {
         return Optional.empty();
-    }
-
-    @Override
-    public <E extends Exception> Try<Void> forEach(ConsumerWithException<T, E> consumer) {
-        return new Failure<Void>(exception);
     }
 }


### PR DESCRIPTION
orElseThrow  in `attempt(()->someAction()).orElseThrow()` catches the excpection in thrown by someAction and throws a RuntimeException with cause the caught Exception. This is inevitable for checked exceptions , but for unchecked exceptions it is not necessary and it creates noise as one has to go and obscures the real failure.

This fix throws the original exception directly when it is a Runtime exception. 

