### PR TITLE
UnixPath: manipulate root

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ wrapper {
 
 allprojects {
     group = 'com.github.bibsysdev'
-    version = '1.7.1'
+    version = '1.7.2'
 
     apply plugin: 'java-library'
     apply plugin: 'jacoco'

--- a/s3/src/main/java/no/unit/nva/s3/UnixPath.java
+++ b/s3/src/main/java/no/unit/nva/s3/UnixPath.java
@@ -18,7 +18,7 @@ public final class UnixPath {
 
     public static final UnixPath EMPTY_PATH = new UnixPath(Collections.emptyList());
     private static final String PATH_DELIMITER = "/";
-    private static final String ROOT = "/";
+    public static final String ROOT = "/";
     public static final UnixPath ROOT_PATH = UnixPath.of(ROOT);
     private static final String EMPTY_STRING = "";
 
@@ -76,7 +76,7 @@ public final class UnixPath {
     public String toString() {
         if (pathIsEmpty(path)) {
             return EMPTY_STRING;
-        } else if (ROOT.equals(path.get(0))) {
+        } else if (isAbsolute()) {
             return avoidWritingRootPathTwice();
         } else {
             return formatPathAsString(path);
@@ -96,6 +96,18 @@ public final class UnixPath {
 
     public String getFilename() {
         return path.get(lastPathElementIndex());
+    }
+
+    public UnixPath addRoot() {
+        return isAbsolute()
+                   ? this
+                   : ROOT_PATH.addChild(this);
+    }
+
+    public UnixPath removeRoot() {
+        return isAbsolute()
+                   ? new UnixPath(this.path.subList(1, path.size()))
+                   : this;
     }
 
     private static Stream<String> extractAllPathElements(String[] path) {
@@ -136,6 +148,10 @@ public final class UnixPath {
 
     private static boolean pathIsEmpty(List<String> path) {
         return Objects.isNull(path) || path.isEmpty();
+    }
+
+    private boolean isAbsolute() {
+        return ROOT.equals(path.get(0));
     }
 
     private String formatPathAsString(List<String> pathArray) {

--- a/s3/src/test/java/no/unit/nva/s3/UnixPathTest.java
+++ b/s3/src/test/java/no/unit/nva/s3/UnixPathTest.java
@@ -1,6 +1,7 @@
 package no.unit.nva.s3;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static no.unit.nva.s3.UnixPath.ROOT;
 import static nva.commons.core.JsonUtils.objectMapper;
 import static nva.commons.core.JsonUtils.objectMapperNoEmpty;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -177,6 +178,35 @@ class UnixPathTest {
             objectMapper.readValue(jsonString, ClassWithUnixPath.class);
 
         assertThat(objectContainingUnixPath.getUnixPath().toString(), is(equalTo(expectedPath)));
+    }
+
+    @Test
+    public void addRootAddsRootToNonAbsoluteUnixPath() {
+        String pathString = "some/path";
+        String expectedPathString = ROOT + pathString;
+        String actualPathString = UnixPath.fromString(pathString).addRoot().toString();
+        assertThat(actualPathString, is(equalTo(expectedPathString)));
+    }
+
+    @Test
+    public void addRootReturnsSamePathWhenPathIsAbsoluteUnixPath() {
+        String expectedPathString = ROOT + "some/path";
+        String actualPathString = UnixPath.fromString(expectedPathString).addRoot().toString();
+        assertThat(actualPathString, is(equalTo(expectedPathString)));
+    }
+
+    @Test
+    public void removeRootRemovesRootToNonAbsoluteUnixPath() {
+        String expectedPathString = "some/path";
+        String actualPathString = UnixPath.fromString(ROOT + expectedPathString).removeRoot().toString();
+        assertThat(actualPathString, is(equalTo(expectedPathString)));
+    }
+
+    @Test
+    public void removeRootReturnsSamePathWhenUnixPathIsNotAbsolute() {
+        String expectedPathString = "some/path";
+        String actualPathString = UnixPath.fromString(expectedPathString).removeRoot().toString();
+        assertThat(actualPathString, is(equalTo(expectedPathString)));
     }
 
     private static class ClassWithUnixPath {


### PR DESCRIPTION
When manipulating URIs and S3 bucket paths we need to add or remove the root. Added this functionality in the UnixPath to avoid code replication.