### PR TITLE
Json serializing in single line

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ wrapper {
 
 allprojects {
     group = 'com.github.bibsysdev'
-    version = '1.7.4'
+    version = '1.7.5'
 
     apply plugin: 'java-library'
     apply plugin: 'jacoco'

--- a/core/src/main/java/nva/commons/core/JsonSerializable.java
+++ b/core/src/main/java/nva/commons/core/JsonSerializable.java
@@ -1,6 +1,6 @@
 package nva.commons.core;
 
-import static nva.commons.core.JsonUtils.objectMapper;
+import static nva.commons.core.JsonUtils.objectMapperSingleLine;
 
 public interface JsonSerializable {
 
@@ -11,7 +11,7 @@ public interface JsonSerializable {
      */
     default String toJsonString() {
         try {
-            return objectMapper.writeValueAsString(this);
+            return objectMapperSingleLine.writeValueAsString(this);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/core/src/main/java/nva/commons/core/JsonUtils.java
+++ b/core/src/main/java/nva/commons/core/JsonUtils.java
@@ -20,31 +20,36 @@ import org.zalando.problem.ProblemModule;
 
 public final class JsonUtils {
 
-    public static final ObjectMapper objectMapperWithEmpty = createJsonParser(Include.ALWAYS);
-    public static final ObjectMapper objectMapperNoEmpty = createJsonParser(Include.NON_EMPTY);
+    private static final boolean PRETTY_JSON = true;
+    private static final boolean JSON_IN_SINLE_LINE = false;
+    public static final ObjectMapper objectMapperWithEmpty = createJsonParser(Include.ALWAYS, PRETTY_JSON);
+    public static final ObjectMapper objectMapperNoEmpty = createJsonParser(Include.NON_EMPTY, PRETTY_JSON);
+    public static final ObjectMapper objectMapperSingleLine = createJsonParser(Include.NON_EMPTY, JSON_IN_SINLE_LINE);
     public static final ObjectMapper objectMapper = objectMapperNoEmpty;
 
     private JsonUtils() {
     }
 
-    private static ObjectMapper createJsonParser(JsonInclude.Include includeEmptyValuesOption) {
+    private static ObjectMapper createJsonParser(JsonInclude.Include includeEmptyValuesOption, boolean prettyJson) {
         JsonFactory jsonFactory =
             new JsonFactory().configure(Feature.ALLOW_SINGLE_QUOTES, true);
 
-        return new ObjectMapper(jsonFactory)
-            .registerModule(new ProblemModule())
-            //TODO: JavaTimeModule belongs to an obsolete library, find alternative
-            .registerModule(new JavaTimeModule())
-            .registerModule(new Jdk8Module())
-            .registerModule(emptyStringAsNullModule())
-            .enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
-            .enable(SerializationFeature.INDENT_OUTPUT)
-            .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
-            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            // We want date-time format, not unix timestamps
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            // Ignore null and empty fields
-            .setSerializationInclusion(includeEmptyValuesOption);
+        ObjectMapper objectMapper = new ObjectMapper(jsonFactory)
+                                        .registerModule(new ProblemModule())
+                                        //TODO: JavaTimeModule belongs to an obsolete library, find alternative
+                                        .registerModule(new JavaTimeModule())
+                                        .registerModule(new Jdk8Module())
+                                        .registerModule(emptyStringAsNullModule())
+                                        .enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+                                        .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                                        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                        // We want date-time format, not unix timestamps
+                                        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                                        // Ignore null and empty fields
+                                        .setSerializationInclusion(includeEmptyValuesOption);
+        return prettyJson
+                   ? objectMapper.enable(SerializationFeature.INDENT_OUTPUT)
+                   : objectMapper.disable(SerializationFeature.INDENT_OUTPUT);
     }
 
     private static SimpleModule emptyStringAsNullModule() {

--- a/core/src/test/java/nva/commons/core/JsonUtilsTest.java
+++ b/core/src/test/java/nva/commons/core/JsonUtilsTest.java
@@ -3,6 +3,8 @@ package nva.commons.core;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
 import static nva.commons.core.JsonUtils.objectMapper;
+import static nva.commons.core.JsonUtils.objectMapperNoEmpty;
+import static nva.commons.core.JsonUtils.objectMapperSingleLine;
 import static nva.commons.core.JsonUtils.objectMapperWithEmpty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -151,13 +153,24 @@ public class JsonUtilsTest {
         assertThat(node.has(NULL_MAP), is(true));
     }
 
+    @Test
+    public void objectMapperSingleLineReturnsObjectsInSingleLine() throws JsonProcessingException {
+        SamplePojo samplePojo = new SamplePojo();
+        samplePojo.setField1("someValue");
+        samplePojo.setField2("someValue");
+        String jsonInSingleLine = objectMapperSingleLine.writeValueAsString(samplePojo);
+        String prettyJson = objectMapperNoEmpty.writeValueAsString(samplePojo);
+        assertThat(jsonInSingleLine, not(containsString(System.lineSeparator())));
+        assertThat(prettyJson, containsString(System.lineSeparator()));
+    }
+
     private TestObjectForOptionals objectWithoutValue() {
         return new TestObjectForOptionals(null);
     }
 
     private TestObjectForOptionals deserialize(JsonNode jsonObjectWithoutValue) {
         return objectMapper.convertValue(jsonObjectWithoutValue,
-            TestObjectForOptionals.class);
+                                         TestObjectForOptionals.class);
     }
 
     private TestObjectForOptionals objectWithSomeValue() {


### PR DESCRIPTION
In some cases, such as exporting data for using with Athena, we need to serialize Json objects in single lines. This allows us to have a centralized way to do so.