### PR TITLE
move UnixPath from s3 package and UriWrapper from publication-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ wrapper {
 
 allprojects {
     group = 'com.github.bibsysdev'
-    version = '1.8.1'
+    version = '1.9.0'
 
     apply plugin: 'java-library'
     apply plugin: 'jacoco'

--- a/core/src/main/java/nva/commons/core/paths/UnixPath.java
+++ b/core/src/main/java/nva/commons/core/paths/UnixPath.java
@@ -1,4 +1,4 @@
-package no.unit.nva.s3;
+package nva.commons.core.paths;
 
 import static java.util.Objects.nonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -14,12 +14,16 @@ import java.util.stream.Stream;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.StringUtils;
 
+/**
+ * Class for manipulating Unix-like paths. Provides a standard way to add children to the paths so that we do not have
+ * to deal all the time with the path delimiters.
+ */
 public final class UnixPath {
 
     public static final UnixPath EMPTY_PATH = new UnixPath(Collections.emptyList());
     public static final String ROOT = "/";
     public static final UnixPath ROOT_PATH = UnixPath.of(ROOT);
-    private static final String PATH_DELIMITER = "/";
+    public static final String PATH_DELIMITER = "/";
     private static final String EMPTY_STRING = "";
 
     private final List<String> path;
@@ -32,7 +36,7 @@ public final class UnixPath {
     public static UnixPath of(String... path) {
         Stream<String> pathElements = extractAllPathElements(path);
         List<String> pathElementsList = addRootIfPresentInOriginalPath(pathElements, path)
-                                            .collect(Collectors.toList());
+            .collect(Collectors.toList());
         return pathIsEmpty(pathElementsList)
                    ? EMPTY_PATH
                    : new UnixPath(pathElementsList);
@@ -121,16 +125,16 @@ public final class UnixPath {
 
     private static Stream<String> splitInputElementsContainingPathDelimiter(Stream<String> pathElements) {
         return pathElements
-                   .map(UnixPath::splitCompositePathElements)
-                   .flatMap(Arrays::stream)
-                   .filter(StringUtils::isNotBlank);
+            .map(UnixPath::splitCompositePathElements)
+            .flatMap(Arrays::stream)
+            .filter(StringUtils::isNotBlank);
     }
 
     private static Stream<String> discardNullArrayElements(String[] path) {
         return Optional.ofNullable(path)
-                   .stream()
-                   .flatMap(Arrays::stream)
-                   .filter(Objects::nonNull);
+            .stream()
+            .flatMap(Arrays::stream)
+            .filter(Objects::nonNull);
     }
 
     //composite path element is an element of the form /folder1/folder2

--- a/core/src/main/java/nva/commons/core/paths/UriWrapper.java
+++ b/core/src/main/java/nva/commons/core/paths/UriWrapper.java
@@ -1,0 +1,79 @@
+package nva.commons.core.paths;
+
+import static nva.commons.core.attempt.Try.attempt;
+import java.net.URI;
+import java.util.Objects;
+import java.util.Optional;
+import nva.commons.core.attempt.Try;
+
+/**
+ * Class for easily building and manipulating URIs. Tools to easily append paths and not have to deal with checking
+ * whether the path delimiter is present or not.
+ */
+public class UriWrapper {
+
+    public static final String EMPTY_FRAGMENT = null;
+    public static final String EMPTY_PATH = null;
+    private final URI uri;
+
+    public UriWrapper(URI uri) {
+        assert Objects.nonNull(uri);
+        this.uri = uri;
+    }
+
+    public UriWrapper(String uri) {
+        this(URI.create(uri));
+    }
+
+    public URI getUri() {
+        return uri;
+    }
+
+    public UriWrapper getHost() {
+        return attempt(() -> new URI(uri.getScheme(), uri.getHost(), EMPTY_PATH, EMPTY_FRAGMENT))
+            .map(UriWrapper::new)
+            .orElseThrow();
+    }
+
+    public UriWrapper addChild(String... path) {
+        return addChild(UnixPath.of(path));
+    }
+
+    /**
+     * Appends a path to the URI.
+     *
+     * @param childPath the path to be appended.
+     * @return a UriWrapper containing the whole path.
+     */
+    public UriWrapper addChild(UnixPath childPath) {
+        UnixPath thisPath = getPath();
+        UnixPath totalPath = thisPath.addChild(childPath).addRoot();
+
+        return attempt(() -> new URI(uri.getScheme(), uri.getHost(), totalPath.toString(), EMPTY_FRAGMENT))
+            .map(UriWrapper::new)
+            .orElseThrow();
+    }
+
+    public UnixPath toS3bucketPath() {
+        return getPath().removeRoot();
+    }
+
+    public UnixPath getPath() {
+        String pathString = uri.getPath();
+        return UnixPath.of(pathString);
+    }
+
+    public Optional<UriWrapper> getParent() {
+        return Optional.of(uri)
+            .map(URI::getPath)
+            .map(UnixPath::of)
+            .flatMap(UnixPath::getParent)
+            .map(attempt(p -> new URI(uri.getScheme(), uri.getHost(), p.toString(), EMPTY_FRAGMENT)))
+            .map(Try::orElseThrow)
+            .map(UriWrapper::new);
+    }
+
+    public String getFilename() {
+        return getPath().getFilename();
+    }
+}

--- a/core/src/test/java/nva/commons/core/paths/UnixPathTest.java
+++ b/core/src/test/java/nva/commons/core/paths/UnixPathTest.java
@@ -1,9 +1,9 @@
-package no.unit.nva.s3;
+package nva.commons.core.paths;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
-import static no.unit.nva.s3.UnixPath.ROOT;
 import static nva.commons.core.JsonUtils.objectMapper;
 import static nva.commons.core.JsonUtils.objectMapperNoEmpty;
+import static nva.commons.core.paths.UnixPath.PATH_DELIMITER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Optional;
+import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -23,44 +24,45 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 class UnixPathTest {
 
     public static final String EMPTY_STRING = "";
+    public static final String NULL_STRING = null;
 
     @Test
     public void ofReturnsPathWithAllPathElementsInOrderWhenInputArrayIsNotEmpty() {
         UnixPath unixPath = UnixPath.of("first", "second", "third");
-        assertThat(unixPath.toString(), is(equalTo("first/second/third")));
+        MatcherAssert.assertThat(unixPath.toString(), is(equalTo("first/second/third")));
     }
 
     @Test
     public void ofReturnsPathWithRootWhenRootIsFirstElement() {
-        UnixPath unixPath = UnixPath.of("/", "first", "second", "third");
-        assertThat(unixPath.toString(), is(equalTo("/first/second/third")));
+        UnixPath unixPath = UnixPath.of(PATH_DELIMITER, "first", "second", "third");
+        MatcherAssert.assertThat(unixPath.toString(), is(equalTo("/first/second/third")));
     }
 
     @Test
     public void ofReturnsEmptyPathWhenInputIsNull() {
-        UnixPath unixPath = UnixPath.of(null);
+        UnixPath unixPath = UnixPath.of(NULL_STRING);
         System.out.println(unixPath);
-        assertThat(unixPath.toString(), is(emptyString()));
+        MatcherAssert.assertThat(unixPath.toString(), is(emptyString()));
     }
 
     @Test
     public void ofReturnsEmptyPathWhenInputIsEmptyArray() {
         UnixPath unixPath = UnixPath.of();
-        assertThat(unixPath.toString(), is(emptyString()));
+        MatcherAssert.assertThat(unixPath.toString(), is(emptyString()));
     }
 
     @Test
     public void fromStringReturnsPathElementsWhenInputIsPathStringWithElementsDividedWithUnixPathDelimiter() {
         String originalPathString = "first/second/third";
         UnixPath unixPath = UnixPath.fromString(originalPathString);
-        assertThat(unixPath.toString(), is(equalTo(originalPathString)));
+        MatcherAssert.assertThat(unixPath.toString(), is(equalTo(originalPathString)));
     }
 
     @Test
     public void fromStringReturnsPathWithRootWhenInputContainsRoot() {
         String originalPathString = "/first/second/third";
         UnixPath unixPath = UnixPath.fromString(originalPathString);
-        assertThat(unixPath.toString(), is(equalTo(originalPathString)));
+        MatcherAssert.assertThat(unixPath.toString(), is(equalTo(originalPathString)));
     }
 
     @Test
@@ -70,7 +72,7 @@ class UnixPathTest {
         String grandChildPath = "fourth/fifth";
         UnixPath actualPath = UnixPath.fromString(parentPath).addChild(childPath).addChild(grandChildPath);
         String expectedPath = "first/second/third/fourth/fifth";
-        assertThat(actualPath.toString(), is(equalTo(expectedPath)));
+        MatcherAssert.assertThat(actualPath.toString(), is(equalTo(expectedPath)));
     }
 
     @Test
@@ -79,14 +81,14 @@ class UnixPathTest {
         String parent = "first/second";
         UnixPath originalPath = UnixPath.of(path);
         Optional<UnixPath> parentPath = originalPath.getParent();
-        assertThat(parentPath.orElseThrow().toString(), is(equalTo(parent)));
+        MatcherAssert.assertThat(parentPath.orElseThrow().toString(), is(equalTo(parent)));
     }
 
     @ParameterizedTest(name = "getParent returns empty optional when Unix Path is empty : \"{0}\"")
     @NullAndEmptySource
     public void getParentReturnsEmptyOptionalWhenUnixPathIsEmpty(String path) {
         UnixPath unixPath = UnixPath.of(path);
-        assertThat(unixPath.getParent(), isEmpty());
+        MatcherAssert.assertThat(unixPath.getParent(), isEmpty());
     }
 
     @Test
@@ -103,7 +105,7 @@ class UnixPathTest {
         UnixPath right = UnixPath.fromString("first//second//third");
         assertThat(left, is(equalTo(right)));
         assertThat(left, is(not(sameInstance(right))));
-        assertThat(right.toString(), is(equalTo("first/second/third")));
+        MatcherAssert.assertThat(right.toString(), is(equalTo("first/second/third")));
     }
 
     @Test
@@ -124,13 +126,13 @@ class UnixPathTest {
     @Test
     public void ofReturnsPathSplittingStringElementsOnPathSeparator() {
         UnixPath path = UnixPath.of("first/second/", "third/fourth", "fifth");
-        assertThat(path.toString(), is(equalTo("first/second/third/fourth/fifth")));
+        MatcherAssert.assertThat(path.toString(), is(equalTo("first/second/third/fourth/fifth")));
     }
 
     @Test
     public void isRootReturnsTrueWhenUnixPathIsRoot() {
         UnixPath path = UnixPath.of("/");
-        assertThat(path.isRoot(), is(true));
+        MatcherAssert.assertThat(path.isRoot(), is(true));
         assertThat(path, is(equalTo(UnixPath.ROOT_PATH)));
     }
 
@@ -138,7 +140,7 @@ class UnixPathTest {
     public void getParentReturnsRootIfPathHasRootAndParentPathIsRoot() {
         UnixPath path = UnixPath.of("/folder");
         UnixPath parent = path.getParent().orElseThrow();
-        assertThat(parent.isRoot(), is(true));
+        MatcherAssert.assertThat(parent.isRoot(), is(true));
         assertThat(parent, is(equalTo(UnixPath.ROOT_PATH)));
     }
 
@@ -149,7 +151,7 @@ class UnixPathTest {
     })
     public void getFilenameReturnsTheLastElementOfaUnixPath(String inputPath, String expectedFilename) {
         UnixPath unixPath = UnixPath.of(inputPath);
-        assertThat(unixPath.getFilename(), is(equalTo(expectedFilename)));
+        MatcherAssert.assertThat(unixPath.getFilename(), is(equalTo(expectedFilename)));
     }
 
     @Test
@@ -177,20 +179,20 @@ class UnixPathTest {
         ClassWithUnixPath objectContainingUnixPath =
             objectMapper.readValue(jsonString, ClassWithUnixPath.class);
 
-        assertThat(objectContainingUnixPath.getField().toString(), is(equalTo(expectedPath)));
+        MatcherAssert.assertThat(objectContainingUnixPath.getField().toString(), is(equalTo(expectedPath)));
     }
 
     @Test
     public void addRootAddsRootToNonAbsoluteUnixPath() {
         String pathString = "some/path";
-        String expectedPathString = ROOT + pathString;
+        String expectedPathString = UnixPath.ROOT + pathString;
         String actualPathString = UnixPath.fromString(pathString).addRoot().toString();
         assertThat(actualPathString, is(equalTo(expectedPathString)));
     }
 
     @Test
     public void addRootReturnsSamePathWhenPathIsAbsoluteUnixPath() {
-        String expectedPathString = ROOT + "some/path";
+        String expectedPathString = UnixPath.ROOT + "some/path";
         String actualPathString = UnixPath.fromString(expectedPathString).addRoot().toString();
         assertThat(actualPathString, is(equalTo(expectedPathString)));
     }
@@ -198,7 +200,7 @@ class UnixPathTest {
     @Test
     public void removeRootRemovesRootToNonAbsoluteUnixPath() {
         String expectedPathString = "some/path";
-        String actualPathString = UnixPath.fromString(ROOT + expectedPathString).removeRoot().toString();
+        String actualPathString = UnixPath.fromString(UnixPath.ROOT + expectedPathString).removeRoot().toString();
         assertThat(actualPathString, is(equalTo(expectedPathString)));
     }
 

--- a/core/src/test/java/nva/commons/core/paths/UnixPathTest.java
+++ b/core/src/test/java/nva/commons/core/paths/UnixPathTest.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Optional;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -29,40 +28,40 @@ class UnixPathTest {
     @Test
     public void ofReturnsPathWithAllPathElementsInOrderWhenInputArrayIsNotEmpty() {
         UnixPath unixPath = UnixPath.of("first", "second", "third");
-        MatcherAssert.assertThat(unixPath.toString(), is(equalTo("first/second/third")));
+        assertThat(unixPath.toString(), is(equalTo("first/second/third")));
     }
 
     @Test
     public void ofReturnsPathWithRootWhenRootIsFirstElement() {
         UnixPath unixPath = UnixPath.of(PATH_DELIMITER, "first", "second", "third");
-        MatcherAssert.assertThat(unixPath.toString(), is(equalTo("/first/second/third")));
+        assertThat(unixPath.toString(), is(equalTo("/first/second/third")));
     }
 
     @Test
     public void ofReturnsEmptyPathWhenInputIsNull() {
         UnixPath unixPath = UnixPath.of(NULL_STRING);
         System.out.println(unixPath);
-        MatcherAssert.assertThat(unixPath.toString(), is(emptyString()));
+        assertThat(unixPath.toString(), is(emptyString()));
     }
 
     @Test
     public void ofReturnsEmptyPathWhenInputIsEmptyArray() {
         UnixPath unixPath = UnixPath.of();
-        MatcherAssert.assertThat(unixPath.toString(), is(emptyString()));
+        assertThat(unixPath.toString(), is(emptyString()));
     }
 
     @Test
     public void fromStringReturnsPathElementsWhenInputIsPathStringWithElementsDividedWithUnixPathDelimiter() {
         String originalPathString = "first/second/third";
         UnixPath unixPath = UnixPath.fromString(originalPathString);
-        MatcherAssert.assertThat(unixPath.toString(), is(equalTo(originalPathString)));
+        assertThat(unixPath.toString(), is(equalTo(originalPathString)));
     }
 
     @Test
     public void fromStringReturnsPathWithRootWhenInputContainsRoot() {
         String originalPathString = "/first/second/third";
         UnixPath unixPath = UnixPath.fromString(originalPathString);
-        MatcherAssert.assertThat(unixPath.toString(), is(equalTo(originalPathString)));
+        assertThat(unixPath.toString(), is(equalTo(originalPathString)));
     }
 
     @Test
@@ -72,7 +71,7 @@ class UnixPathTest {
         String grandChildPath = "fourth/fifth";
         UnixPath actualPath = UnixPath.fromString(parentPath).addChild(childPath).addChild(grandChildPath);
         String expectedPath = "first/second/third/fourth/fifth";
-        MatcherAssert.assertThat(actualPath.toString(), is(equalTo(expectedPath)));
+        assertThat(actualPath.toString(), is(equalTo(expectedPath)));
     }
 
     @Test
@@ -81,14 +80,14 @@ class UnixPathTest {
         String parent = "first/second";
         UnixPath originalPath = UnixPath.of(path);
         Optional<UnixPath> parentPath = originalPath.getParent();
-        MatcherAssert.assertThat(parentPath.orElseThrow().toString(), is(equalTo(parent)));
+        assertThat(parentPath.orElseThrow().toString(), is(equalTo(parent)));
     }
 
     @ParameterizedTest(name = "getParent returns empty optional when Unix Path is empty : \"{0}\"")
     @NullAndEmptySource
     public void getParentReturnsEmptyOptionalWhenUnixPathIsEmpty(String path) {
         UnixPath unixPath = UnixPath.of(path);
-        MatcherAssert.assertThat(unixPath.getParent(), isEmpty());
+        assertThat(unixPath.getParent(), isEmpty());
     }
 
     @Test
@@ -105,7 +104,7 @@ class UnixPathTest {
         UnixPath right = UnixPath.fromString("first//second//third");
         assertThat(left, is(equalTo(right)));
         assertThat(left, is(not(sameInstance(right))));
-        MatcherAssert.assertThat(right.toString(), is(equalTo("first/second/third")));
+        assertThat(right.toString(), is(equalTo("first/second/third")));
     }
 
     @Test
@@ -126,13 +125,13 @@ class UnixPathTest {
     @Test
     public void ofReturnsPathSplittingStringElementsOnPathSeparator() {
         UnixPath path = UnixPath.of("first/second/", "third/fourth", "fifth");
-        MatcherAssert.assertThat(path.toString(), is(equalTo("first/second/third/fourth/fifth")));
+        assertThat(path.toString(), is(equalTo("first/second/third/fourth/fifth")));
     }
 
     @Test
     public void isRootReturnsTrueWhenUnixPathIsRoot() {
         UnixPath path = UnixPath.of("/");
-        MatcherAssert.assertThat(path.isRoot(), is(true));
+        assertThat(path.isRoot(), is(true));
         assertThat(path, is(equalTo(UnixPath.ROOT_PATH)));
     }
 
@@ -140,7 +139,7 @@ class UnixPathTest {
     public void getParentReturnsRootIfPathHasRootAndParentPathIsRoot() {
         UnixPath path = UnixPath.of("/folder");
         UnixPath parent = path.getParent().orElseThrow();
-        MatcherAssert.assertThat(parent.isRoot(), is(true));
+        assertThat(parent.isRoot(), is(true));
         assertThat(parent, is(equalTo(UnixPath.ROOT_PATH)));
     }
 
@@ -151,7 +150,7 @@ class UnixPathTest {
     })
     public void getFilenameReturnsTheLastElementOfaUnixPath(String inputPath, String expectedFilename) {
         UnixPath unixPath = UnixPath.of(inputPath);
-        MatcherAssert.assertThat(unixPath.getFilename(), is(equalTo(expectedFilename)));
+        assertThat(unixPath.getFilename(), is(equalTo(expectedFilename)));
     }
 
     @Test
@@ -179,7 +178,7 @@ class UnixPathTest {
         ClassWithUnixPath objectContainingUnixPath =
             objectMapper.readValue(jsonString, ClassWithUnixPath.class);
 
-        MatcherAssert.assertThat(objectContainingUnixPath.getField().toString(), is(equalTo(expectedPath)));
+        assertThat(objectContainingUnixPath.getField().toString(), is(equalTo(expectedPath)));
     }
 
     @Test

--- a/core/src/test/java/nva/commons/core/paths/UriWrapperTest.java
+++ b/core/src/test/java/nva/commons/core/paths/UriWrapperTest.java
@@ -1,0 +1,86 @@
+package nva.commons.core.paths;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import java.net.URI;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class UriWrapperTest {
+
+    public static final String HOST = "http://www.example.org";
+    private static final String ROOT = "/";
+
+    @Test
+    public void getPathRemovesPathDelimiterFromTheEndOfTheUri() {
+        String inputPath = "/some/folder/file.json/";
+        UriWrapper uriWrapper = new UriWrapper("http://www.example.org" + inputPath);
+        String actualPath = uriWrapper.getPath().toString();
+        String expectedPath = "/some/folder/file.json";
+        assertThat(actualPath, is(equalTo(expectedPath)));
+    }
+
+    @Test
+    public void getParentReturnsParentPathIfParentExists() {
+        UriWrapper uriWrapper = new UriWrapper(HOST + "/level1/level2/file.json");
+        UriWrapper parent = uriWrapper.getParent().orElseThrow();
+        assertThat(parent.getPath().toString(), is(equalTo("/level1/level2")));
+        UriWrapper grandParent = parent.getParent().orElseThrow();
+        assertThat(grandParent.getPath().toString(), is(equalTo("/level1")));
+    }
+
+    @Test
+    public void getParentReturnsEmptyWhenPathIsRoot() {
+        UriWrapper uriWrapper = new UriWrapper(HOST + "/");
+        Optional<UriWrapper> parent = uriWrapper.getParent();
+        assertThat(parent.isEmpty(), is(true));
+    }
+
+    @Test
+    public void getHostReturnsHostUri() {
+        UriWrapper uriWrapper = new UriWrapper(HOST + "/some/path/is.here");
+        URI expectedUri = URI.create(HOST);
+        assertThat(uriWrapper.getHost().getUri(), is(equalTo(expectedUri)));
+    }
+
+    @Test
+    public void addChildAddsChildToPath() {
+        String originalPath = "/some/path";
+        UriWrapper parent = new UriWrapper(HOST + originalPath);
+        UriWrapper child = parent.addChild("level1", "level2", "level3");
+        URI expectedChildUri = URI.create(HOST + originalPath + "/level1/level2/level3");
+        assertThat(child.getUri(), is(equalTo(expectedChildUri)));
+
+        UriWrapper anotherChild = parent.addChild("level4").addChild("level5");
+        URI expectedAnotherChildUri = URI.create(HOST + originalPath + "/level4/level5");
+        assertThat(anotherChild.getUri(), is(equalTo(expectedAnotherChildUri)));
+    }
+
+    @Test
+    public void addChildReturnsPathWithChildWhenChildDoesNotStartWithDelimiter() {
+        UriWrapper parentPath = new UriWrapper(HOST);
+        String inputChildPath = "some/path";
+        URI expectedResult = URI.create(HOST + ROOT + inputChildPath);
+        UriWrapper actualResult = parentPath.addChild(inputChildPath);
+        assertThat(actualResult.getUri(), is(equalTo(expectedResult)));
+    }
+
+    @Test
+    public void toS3BucketPathReturnsPathWithoutRoot() {
+        String expectedPath = "parent1/parent2/filename.txt";
+        URI s3Uri = URI.create("s3://somebucket" + ROOT + expectedPath);
+        UriWrapper wrapper = new UriWrapper(s3Uri);
+        UnixPath s3Path = wrapper.toS3bucketPath();
+        assertThat(s3Path.toString(), is(equalTo(expectedPath)));
+    }
+
+    @Test
+    public void getFilenameReturnsFilenameOfUri() {
+        String expectedFilename = "filename.txt";
+        String filePath = String.join(UnixPath.PATH_DELIMITER, "parent1", "parent2", expectedFilename);
+        URI s3Uri = URI.create("s3://somebucket" + ROOT + filePath);
+        UriWrapper wrapper = new UriWrapper(s3Uri);
+        assertThat(wrapper.getFilename(), is(equalTo(expectedFilename)));
+    }
+}

--- a/s3/src/main/java/no/unit/nva/s3/S3Driver.java
+++ b/s3/src/main/java/no/unit/nva/s3/S3Driver.java
@@ -16,6 +16,7 @@ import java.util.zip.GZIPInputStream;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.ioutils.IoUtils;
+import nva.commons.core.paths.UnixPath;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;

--- a/s3/src/test/java/no/unit/nva/s3/S3DriverTest.java
+++ b/s3/src/test/java/no/unit/nva/s3/S3DriverTest.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import nva.commons.core.ioutils.IoUtils;
+import nva.commons.core.paths.UnixPath;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;


### PR DESCRIPTION
Move UnixPath from the s3 package to core and the UriWrapper from the publication-api to commons.

The UnixPath, allows path manipulations independent of platform and the UriWrapper allows easy manipulations of URIs such as adding children or getting parent paths 