### PR TITLE
Listing s3 files with paging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ wrapper {
 
 allprojects {
     group = 'com.github.bibsysdev'
-    version = '1.10.0'
+    version = '1.11.0'
 
     apply plugin: 'java-library'
     apply plugin: 'jacoco'

--- a/s3/src/main/java/no/unit/nva/s3/ListingResult.java
+++ b/s3/src/main/java/no/unit/nva/s3/ListingResult.java
@@ -1,0 +1,29 @@
+package no.unit.nva.s3;
+
+import java.util.List;
+import nva.commons.core.paths.UnixPath;
+
+public class ListingResult {
+
+    private final String listingStartingPoint;
+    private final List<UnixPath> files;
+    private final boolean truncated;
+
+    public ListingResult(List<UnixPath> files, String listingStartingPoint, boolean isTruncated) {
+        this.listingStartingPoint = listingStartingPoint;
+        this.files = files;
+        this.truncated = isTruncated;
+    }
+
+    public String getListingStartingPoint() {
+        return listingStartingPoint;
+    }
+
+    public List<UnixPath> getFiles() {
+        return files;
+    }
+
+    public boolean isTruncated() {
+        return truncated;
+    }
+}


### PR DESCRIPTION
The changes here are the following:
1. Make the method listFiles return only a partial result (page) of filenames within an S3 folder and information for requesting the next page.
2. Make the new listFiles method incompatible with the existing version to force the library clients to choose the desired version.
3. Maintain the functionality of listing allFiles at once by creating a new method with name listAllFiles.

### Small description of the refactoring.
This is the first step for creating more scalable processes for imports of data from S3. 
The 2nd step will be to create lambda functions that are tail-recursive (i.e. the lambda function will call itself as its last action) in order to process the next batch. This will allow us to create batch jobs without creating EC2 instances. 
The 3rd step will be to make the ES batch index job to work directly on Dynamo and not on S3.
