### PR TITLE
FakeS3Client lists files in order they were submitted

### DIFF
--- a/nvatestutils/build.gradle
+++ b/nvatestutils/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     implementation project(":core")
     implementation project(":eventhandlers")
-    testImplementation project(":doi")
+
 
 
     implementation group: 'org.mockito', name: 'mockito-core', version: project.ext.mockitoVersion
@@ -22,7 +22,7 @@ dependencies {
     implementation group: 'com.github.javafaker', name: 'javafaker', version: project.ext.javaFaker
 
     testImplementation project(":doi")
-    testImplementation project(":nvatestutils")
+    testImplementation project(":doi")
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: project.ext.jupiterVersion
     testImplementation group: 'org.mockito', name: 'mockito-core', version: project.ext.mockitoVersion
 

--- a/nvatestutils/src/main/java/no/unit/nva/stubs/FakeS3Client.java
+++ b/nvatestutils/src/main/java/no/unit/nva/stubs/FakeS3Client.java
@@ -5,10 +5,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.ioutils.IoUtils;
@@ -36,7 +37,7 @@ public class FakeS3Client implements S3Client {
     }
 
     public FakeS3Client(Map<String, InputStream> filesAndContent) {
-        this.filesAndContent = new ConcurrentHashMap<>(filesAndContent);
+        this.filesAndContent = new LinkedHashMap<>(filesAndContent);
     }
 
     //TODO: fix if necessary
@@ -59,7 +60,8 @@ public class FakeS3Client implements S3Client {
      */
     @Override
     public ListObjectsResponse listObjects(ListObjectsRequest listObjectsRequest) {
-        List<String> fileKeys = filesAndContent.keySet().stream().sorted().collect(Collectors.toList());
+        List<String> fileKeys = new ArrayList<>(filesAndContent.keySet());
+
         var startIndex = calculateStartIndex(fileKeys, listObjectsRequest.marker());
         var endIndex = calculateEndIndex(fileKeys, listObjectsRequest.marker(), listObjectsRequest.maxKeys());
         var truncated = endIndex < fileKeys.size();

--- a/nvatestutils/src/test/java/no/unit/nva/stubs/FakeS3ClientTest.java
+++ b/nvatestutils/src/test/java/no/unit/nva/stubs/FakeS3ClientTest.java
@@ -1,27 +1,38 @@
 package no.unit.nva.stubs;
 
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import com.github.javafaker.Faker;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import nva.commons.core.ioutils.IoUtils;
+import nva.commons.core.paths.UnixPath;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 class FakeS3ClientTest {
 
     public static final Faker FAKER = Faker.instance();
     public static final URI SOME_URI = URI.create("s3://bucket/some/path/file.txt");
+    public static final String SOME_BUCKET = "somebucket";
+    public static final String SOME_BUCKET_URI = "s3://" + SOME_BUCKET;
 
     @Test
     public void putObjectMakesContentAvailableForGetting() {
@@ -39,10 +50,49 @@ class FakeS3ClientTest {
     public void putObjectDoesNotAlterInputDataToFakeS3Client() {
         Map<String, InputStream> inputData = new ConcurrentHashMap<>();
         inputData.put(randomString(), IoUtils.stringToStream(randomString()));
-        ConcurrentHashMap<String, InputStream> inputDataCopy = new ConcurrentHashMap<>(inputData);
+        Map<String, InputStream> inputDataCopy = new ConcurrentHashMap<>(inputData);
         FakeS3Client fakeS3Client = new FakeS3Client(inputData);
         putObject(fakeS3Client, SOME_URI, randomString());
         assertThat(inputData, is(equalTo(inputDataCopy)));
+    }
+
+    @Test
+    public void shouldListInsertedFilesByInsertionOrder() {
+        var sampleFilenames = createLargeSetOfRandomFilenames();
+        var s3Client = new FakeS3Client();
+        var listObjectsRequest = insertFilesToBucketInOrder(sampleFilenames, s3Client);
+        var response = s3Client.listObjects(listObjectsRequest);
+        var actualFilenames = extractFilenamesFromResponse(response);
+
+        assertThat(actualFilenames, contains(sampleFilenames.toArray(String[]::new)));
+    }
+
+    private List<String> extractFilenamesFromResponse(ListObjectsResponse response) {
+        return response.contents().stream()
+            .map(S3Object::key)
+            .map(UnixPath::of)
+            .map(UnixPath::removeRoot)
+            .map(UnixPath::toString)
+            .collect(Collectors.toList());
+    }
+
+    private ListObjectsRequest insertFilesToBucketInOrder(List<String> sampleFilenames,
+                                                          FakeS3Client s3Client) {
+        for (var filename : sampleFilenames) {
+            putObject(s3Client, URI.create(SOME_BUCKET_URI + "/" + filename), randomString());
+        }
+        var listObjectsRequest = ListObjectsRequest.builder()
+            .bucket(SOME_BUCKET)
+            .maxKeys(sampleFilenames.size())
+            .build();
+        return listObjectsRequest;
+    }
+
+    private List<String> createLargeSetOfRandomFilenames() {
+        return IntStream.range(0, 100)
+            .boxed()
+            .map(i -> randomString())
+            .collect(Collectors.toList());
     }
 
     private ResponseBytes<GetObjectResponse> getObject(FakeS3Client fakeS3Client, URI s3Uri) {
@@ -63,9 +113,5 @@ class FakeS3ClientTest {
 
         fakeS3Client.putObject(putObjectRequest,
                                RequestBody.fromBytes(expectedContent.getBytes(StandardCharsets.UTF_8)));
-    }
-
-    private String randomString() {
-        return FAKER.lorem().sentence(10);
     }
 }

--- a/s3/src/main/java/no/unit/nva/s3/S3Driver.java
+++ b/s3/src/main/java/no/unit/nva/s3/S3Driver.java
@@ -135,6 +135,12 @@ public class S3Driver {
         return insertAndCompressObjects(s3Folder, content);
     }
 
+    @JacocoGenerated
+    @Deprecated
+    public URI insertAndCompressFiles(List<String> content) throws IOException {
+        return insertAndCompressObjects(content);
+    }
+
     public URI insertAndCompressObjects(UnixPath s3Folder, List<String> content) throws IOException {
         UnixPath path = filenameForZippedFile(s3Folder);
         PutObjectRequest putObjectRequest = newPutObjectRequest(path);
@@ -147,12 +153,6 @@ public class S3Driver {
 
     public URI insertAndCompressObjects(List<String> content) throws IOException {
         return insertAndCompressObjects(UnixPath.EMPTY_PATH, content);
-    }
-
-    @JacocoGenerated
-    @Deprecated
-    public URI insertAndCompressFiles(List<String> content) throws IOException {
-        return insertAndCompressObjects(content);
     }
 
     public List<String> getFiles(UnixPath folder) {


### PR DESCRIPTION
In order to make pagination testing easier, we force FakeS3Client to list the objects in the order they were submitted