### PR TITLE
Generic EventReference becomes part of nva-commons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ wrapper {
 
 allprojects {
     group = 'com.github.bibsysdev'
-    version = '1.16.10'
+    version = '1.16.11'
 
     apply plugin: 'java-library'
     apply plugin: 'jacoco'

--- a/eventhandlers/src/main/java/no/unit/nva/events/handlers/EventHandlersConfig.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/handlers/EventHandlersConfig.java
@@ -7,7 +7,7 @@ public final class EventHandlersConfig {
 
     //Events are considered internal operations. Therefore, the default objectMapper is the one that saves
     // the most space. If other mapper is necessary, it can be set accordingly.
-    /* default */ static final ObjectMapper defaultEventObjectMapper = dynamoObjectMapper;
+    public static final ObjectMapper defaultEventObjectMapper = dynamoObjectMapper;
 
     private EventHandlersConfig() {
     }

--- a/eventhandlers/src/main/java/no/unit/nva/events/models/EventReference.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/models/EventReference.java
@@ -1,0 +1,65 @@
+package no.unit.nva.events.models;
+
+import static no.unit.nva.events.handlers.EventHandlersConfig.defaultEventObjectMapper;
+import static nva.commons.core.attempt.Try.attempt;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.net.URI;
+import java.util.Objects;
+import nva.commons.core.JacocoGenerated;
+import nva.commons.core.JsonSerializable;
+
+/**
+ * An {@link EventReference} is a reference to an event that has happened and the associated data are stored to a
+ * location. The location is stored in the EventReference as a URI. The {@link EventReference} contains also the topic
+ * of the event
+ */
+public class EventReference implements JsonSerializable {
+
+    public static final String TOPIC = "topic";
+    public static final String URI = "uri";
+    @JsonProperty(TOPIC)
+    private final String topic;
+    @JsonProperty(URI)
+    private final URI uri;
+
+    @JsonCreator
+    public EventReference(@JsonProperty(TOPIC) String topic,
+                          @JsonProperty(URI) URI uri) {
+        this.topic = topic;
+        this.uri = uri;
+    }
+
+    public static EventReference fromJson(String json) {
+        return attempt(() -> defaultEventObjectMapper.readValue(json, EventReference.class)).orElseThrow();
+    }
+
+    @JacocoGenerated
+    public String getTopic() {
+        return topic;
+    }
+
+    @JacocoGenerated
+    public URI getUri() {
+        return uri;
+    }
+
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+        return Objects.hash(getTopic(), getUri());
+    }
+
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof EventReference)) {
+            return false;
+        }
+        EventReference that = (EventReference) o;
+        return Objects.equals(getTopic(), that.getTopic()) && Objects.equals(getUri(), that.getUri());
+    }
+}

--- a/eventhandlers/src/test/java/no/unit/nva/events/models/EventReferenceTest.java
+++ b/eventhandlers/src/test/java/no/unit/nva/events/models/EventReferenceTest.java
@@ -1,0 +1,32 @@
+package no.unit.nva.events.models;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.StringContains.containsString;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+class EventReferenceTest {
+
+    @Test
+    void shouldSerializeToJsonObjectThatContainsTopicAndUri() {
+        String expectedTopic = randomString();
+        URI expectedUri = randomUri();
+        EventReference eventReference = new EventReference(expectedTopic, expectedUri);
+        String json = eventReference.toJsonString();
+        assertThat(json, containsString(expectedTopic));
+        assertThat(json, containsString(expectedUri.toString()));
+    }
+
+    @Test
+    void shouldDeSerializeFromJsonObjectWithoutInformationLoss() {
+        String expectedTopic = randomString();
+        URI expectedUri = randomUri();
+        EventReference eventReference = new EventReference(expectedTopic, expectedUri);
+        EventReference deserializedEventReference = EventReference.fromJson(eventReference.toJsonString());
+        assertThat(deserializedEventReference, is(equalTo(eventReference)));
+    }
+}


### PR DESCRIPTION
Class for representing the generic event which has only a topic and an  (S3)  URI