### PR TITLE
upgrade to gradle 7.3 (wip)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ plugins {
     id 'base'
     id 'checkstyle'
     id 'pmd'
-    id 'nebula.lint' version '17.1.1'
+    id 'nebula.lint'
     id 'maven-publish'
     id 'signing'
-    id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
+    id 'io.github.gradle-nexus.publish-plugin'
 }
 
 nexusPublishing {
@@ -20,12 +20,12 @@ nexusPublishing {
 
 wrapper {
     distributionType = Wrapper.DistributionType.ALL
-    gradleVersion = "6.7"
+    gradleVersion = "7.3"
 }
 
 allprojects {
     group = 'com.github.bibsysdev'
-    version = '1.16.12'
+    version = '1.16.14'
 
     apply plugin: 'java-library'
     apply plugin: 'jacoco'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    // Support convention plugins written in Groovy. Convention plugins are build scripts in 'src/main' that automatically become available as plugins in the main build.
+    id 'groovy-gradle-plugin'
+}
+
+repositories {
+    // Use the plugin portal to apply community plugins in convention plugins.
+    gradlePluginPortal()
+    mavenCentral()
+}
+
+wrapper {
+    distributionType = Wrapper.DistributionType.ALL
+    gradleVersion = "7.2"
+}
+
+
+dependencies {
+    implementation group: 'nebula.lint', name: 'nebula.lint.gradle.plugin', version: '17.2.3'
+    implementation group: 'org.jacoco', name: 'org.jacoco.core', version: '0.8.7'
+    implementation group: 'org.jacoco', name: 'org.jacoco.report', version: '0.8.7'
+    implementation group: 'io.github.gradle-nexus', name: 'publish-plugin', version: '1.1.0'
+}

--- a/buildSrc/src/main/groovy/nvacommons.gradlelint.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.gradlelint.gradle
@@ -1,0 +1,5 @@
+plugins {
+    id 'nebula.lint'
+}
+
+gradleLint.rules = ['unused-dependency']

--- a/buildSrc/src/main/groovy/nvacommons.jacoco-merge.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.jacoco-merge.gradle
@@ -1,0 +1,62 @@
+//For generating one unified coverage report
+def getProjectList() {
+    // These projects are considered. Replace with a different list as needed.
+    subprojects + project
+}
+
+def getReportTasks(JacocoReport pRootTask) {
+    getProjectList().collect {
+        it.tasks.withType(JacocoReport).findAll { it != pRootTask }
+    }.flatten()
+}
+
+task jacocoMerge(type: JacocoMerge) {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = 'Merge the JaCoCo data files from all subprojects into one'
+    project.afterEvaluate {
+        // do it at the end of the config phase to be sure all information is present
+        FileCollection execFiles = project.objects.fileCollection()   // an empty FileCollection
+        getProjectList().each { Project subproject ->
+            if (subproject.pluginManager.hasPlugin('jacoco')) {
+                def testTasks = subproject.tasks.withType(Test)
+                dependsOn(testTasks)   // ensure that .exec files are actually present
+
+                testTasks.each { Test task ->
+                    // The JacocoTaskExtension is the source of truth for the location of the .exec file.
+                    JacocoTaskExtension extension = task.getExtensions().findByType(JacocoTaskExtension.class)
+                    if (extension != null) {
+                        execFiles.from extension.getDestinationFile()
+                    }
+                }
+            }
+        }
+        executionData = execFiles
+    }
+    doFirst {
+        // .exec files might be missing if a project has no tests. Filter in execution phase.
+        executionData = executionData.filter { it.canRead() }
+    }
+}
+
+task jacocoRootReport(type: JacocoReport, dependsOn: tasks.jacocoMerge) {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = 'Generates an aggregate report from all subprojects'
+
+    logger.lifecycle 'Using aggregated file: ' + tasks.jacocoMerge.destinationFile
+    executionData.from tasks.jacocoMerge.destinationFile
+
+    project.afterEvaluate {
+        // The JacocoReport tasks are the source of truth for class files and sources.
+        def reportTasks = getReportTasks(tasks.jacocoRootReport)
+        classDirectories.from project.files({
+            reportTasks.collect { it.classDirectories }.findAll { it != null }
+        })
+        sourceDirectories.from project.files({
+            reportTasks.collect { it.sourceDirectories }.findAll { it != null }
+        })
+    }
+
+    reports {
+        xml.enabled true
+    }
+}

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -1,0 +1,73 @@
+plugins {
+    id 'java'
+    id 'jacoco'
+    id 'checkstyle'
+    id 'pmd'
+    id 'idea'
+    id 'nebula.lint'
+}
+
+group 'com.github.bibsysdev'
+version = '1.16.12'
+
+repositories {
+    mavenCentral()
+    maven { url "https://jitpack.io" }
+}
+
+test {
+    useJUnitPlatform {}
+    failFast = true
+    finalizedBy(jacocoTestReport)
+}
+
+jacocoTestReport {
+    dependsOn(test)
+    reports {
+        xml.enabled true
+    }
+}
+
+pmd {
+    ruleSetConfig = rootProject.resources.text.fromFile('config/pmd/ruleset.xml')
+    ruleSets = []
+    ignoreFailures = false
+    pmdMain {}
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                counter = 'METHOD'
+                value = 'COVEREDRATIO'
+                minimum = 1.000
+            }
+        }
+
+        rule {
+            limit {
+                counter = 'CLASS'
+                value = 'COVEREDRATIO'
+                minimum = 1.000
+            }
+        }
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification
+jacocoTestCoverageVerification.dependsOn(jacocoTestReport)
+
+checkstyle {
+    configFile = rootProject.resources.text.fromFile('config/checkstyle/checkstyle.xml').asFile()
+    showViolations = true
+}
+
+tasks.withType(Checkstyle) {
+    reports {
+        xml.enabled false
+        html.enabled true
+        html.stylesheet rootProject.resources.text.fromFile('config/checkstyle/checkstyle-simple.xsl')
+    }
+}
+

--- a/buildSrc/src/main/groovy/nvacommons.publish-maven.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.publish-maven.gradle
@@ -1,0 +1,73 @@
+plugins {
+    id 'maven-publish'
+    id 'signing'
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = project.name
+            from components.java
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
+                }
+                usage('java-runtime') {
+                    fromResolutionResult()
+                }
+            }
+            pom {
+                name = project.name
+                description = 'A commons library for the NVA project'
+                url = 'https://github.com/BIBSYSDEV/nva-commons'
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'http://www.opensource.org/licenses/mit-license.php'
+                    }
+                }
+                developers {
+                    developer {
+                        name = 'Orestis Gkorgkas'
+                        email = 'og@unit.no'
+                        organization = 'UNIT'
+                        organizationUrl = 'https://www.unit.no/'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/BIBSYSDEV/nva-commons.git'
+                    developerConnection = 'scm:git:ssh://github.com/BIBSYSDEV/nva-commons.git'
+                    url = 'https://github.com/BIBSYSDEV/nva-commons/tree/main'
+                }
+            }
+        }
+    }
+}
+
+def gitBranch() {
+    def branch = ""
+    def proc = "git rev-parse --abbrev-ref HEAD".execute()
+    proc.in.eachLine { line -> branch = line }
+    proc.err.eachLine { line -> println line }
+    proc.waitFor()
+    branch
+}
+
+boolean isMainBranch() {
+    def branch = gitBranch()
+    return ((branch == "master" || branch == "main"))
+}
+
+signing {
+    if (isMainBranch()) {
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publishing.publications.mavenJava
+    }
+}

--- a/buildSrc/src/main/groovy/nvacommons.root.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.root.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'io.github.gradle-nexus.publish-plugin'
+    id 'nvacommons.gradlelint'
+    id 'nvacommons.java-conventions'
+    id 'nvacommons.jacoco-merge'
+}
+
+//workaround for jacoco-merge to work
+allprojects {
+    apply plugin: 'nvacommons.java-conventions'
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            username = findProperty("sonatypeUsername")
+            password = findProperty("sonatypePassword")
+            stagingProfileId = "5ba11e4895739"
+        }
+    }
+}
+
+build {
+    finalizedBy jacocoRootReport
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This is the first PR in order to migrate nva-commons to the new style. 
Actions:
1. Upgrade to gradle 7,
2. Add the plugin files (copied from nva-filemodel) but do not use
3. Update the publish plugin module with the correct information.