### PR TITLE
authorization: create a default secrets-based authorizer

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.18.5'
+version = '1.18.6'
 
 
 repositories {

--- a/lambdaauthorizer/build.gradle
+++ b/lambdaauthorizer/build.gradle
@@ -7,12 +7,20 @@ dependencies {
     implementation project(":core")
     implementation project(":apigateway")
     implementation project(":logutils")
-    implementation libs.bundles.logging
+    implementation project(":secrets")
 
+    implementation libs.aws.sdk2.secrets
+
+    implementation libs.bundles.logging
     implementation libs.jackson.databind
     implementation libs.guava
 
     testImplementation libs.bundles.testing
     testImplementation project(":nvatestutils")
 
+}
+
+test{
+    environment "API_KEY_SECRET_NAME","secretName-1234"
+    environment "API_KEY_SECRET_KEY","secretKey-1234"
 }

--- a/lambdaauthorizer/src/main/java/no/unit/commons/apigateway/authentication/DefaultRequestAuthorizer.java
+++ b/lambdaauthorizer/src/main/java/no/unit/commons/apigateway/authentication/DefaultRequestAuthorizer.java
@@ -1,0 +1,45 @@
+package no.unit.commons.apigateway.authentication;
+
+import nva.commons.core.Environment;
+import nva.commons.core.JacocoGenerated;
+import nva.commons.secrets.SecretsReader;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+
+/**
+ * A simple Lambda Authorizer. The class can be used by extending it and adding in the default constructor the principal
+ * id value.
+ */
+public class DefaultRequestAuthorizer extends RequestAuthorizer {
+
+    private static final Environment ENVIRONMENT = new Environment();
+    protected static final String API_KEY_SECRET_NAME = ENVIRONMENT.readEnv("API_KEY_SECRET_NAME");
+    protected static final String API_KEY_SECRET_KEY = ENVIRONMENT.readEnv("API_KEY_SECRET_KEY");
+    private final SecretsReader secretsReader;
+    private final String principalIdentifier;
+
+    /**
+     * @param principalId A string describing the service tha is using the Authorizer.
+     */
+    @JacocoGenerated
+    public DefaultRequestAuthorizer(String principalId) {
+        this(SecretsReader.defaultSecretsManagerClient(), principalId);
+    }
+
+    public DefaultRequestAuthorizer(SecretsManagerClient secretsClient,
+                                    String principalId) {
+        super(ENVIRONMENT);
+        this.secretsReader = new SecretsReader(secretsClient);
+        this.principalIdentifier = principalId;
+    }
+
+    @Override
+    protected String principalId() {
+        return principalIdentifier;
+    }
+
+    @Override
+    protected String fetchSecret() {
+        var sercet = secretsReader.fetchSecret(API_KEY_SECRET_NAME, API_KEY_SECRET_KEY);
+        return sercet;
+    }
+}

--- a/lambdaauthorizer/src/main/java/no/unit/commons/apigateway/authentication/DefaultRequestAuthorizer.java
+++ b/lambdaauthorizer/src/main/java/no/unit/commons/apigateway/authentication/DefaultRequestAuthorizer.java
@@ -18,6 +18,8 @@ public class DefaultRequestAuthorizer extends RequestAuthorizer {
     private final String principalIdentifier;
 
     /**
+     * The constructor that should be inherited by the default constructor of the custom Lambda Authorizer.
+     *
      * @param principalId A string describing the service tha is using the Authorizer.
      */
     @JacocoGenerated

--- a/lambdaauthorizer/src/test/java/no/unit/commons/apigateway/authentication/DefaultRequestAuthorizerTest.java
+++ b/lambdaauthorizer/src/test/java/no/unit/commons/apigateway/authentication/DefaultRequestAuthorizerTest.java
@@ -1,0 +1,125 @@
+package no.unit.commons.apigateway.authentication;
+
+import static no.unit.commons.apigateway.authentication.RequestAuthorizerTest.METHOD_ARN_FIELD;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.net.HttpHeaders;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import no.unit.nva.testutils.HandlerRequestBuilder;
+import nva.commons.apigateway.exceptions.ForbiddenException;
+import nva.commons.core.JsonUtils;
+import nva.commons.logutils.LogUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+
+class DefaultRequestAuthorizerTest {
+
+    public static final String WILDCARD = "*";
+    public static final Context CONTEXT = mock(Context.class);
+    private static final String SECRET_NAME_SET_IN_TEST = "secretName-1234";
+    private static final String SECRET_KEY_SET_IN_TEST = "secretKey-1234";
+    private String expectedApiKey;
+    private DefaultRequestAuthorizer handler;
+    private ByteArrayOutputStream outputStream;
+    private String inputMethodArn;
+    private String arnForAllowingAllActionsOnLambda;
+
+    @BeforeEach
+    public void init() {
+        this.expectedApiKey = randomString();
+        this.inputMethodArn = String.join(RequestAuthorizer.PATH_DELIMITER, randomString(), randomString());
+        this.arnForAllowingAllActionsOnLambda =
+            String.join(RequestAuthorizer.PATH_DELIMITER, inputMethodArn, WILDCARD, WILDCARD);
+        this.handler = new DefaultRequestAuthorizer(setupSecretsClient(), randomString());
+        this.outputStream = new ByteArrayOutputStream();
+    }
+
+    @Test
+    void shouldReturnAuthPolicyWhenApiKeyIsValid() throws IOException, ForbiddenException {
+        var input = requestWithValidApiKey();
+        var returnedPolicy = sendRequestToHandler(input);
+        var expectedPolicy = handler.createAllowAuthPolicy(arnForAllowingAllActionsOnLambda);
+        assertThat(returnedPolicy, is(equalTo(expectedPolicy)));
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenApiKeyIsInvalid() throws IOException, ForbiddenException {
+        final var appender = LogUtils.getTestingAppenderForRootLogger();
+        var input = requestWithInvalidApiKey();
+        var returnedPolicy = sendRequestToHandler(input);
+        var expectedPolicy = handler.createDenyAuthPolicy();
+        assertThat(returnedPolicy, is(equalTo(expectedPolicy)));
+        assertThat(appender.getMessages(), containsString(ForbiddenException.DEFAULT_MESSAGE));
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenApiKeyIsMissing() throws IOException, ForbiddenException {
+        final var appender = LogUtils.getTestingAppenderForRootLogger();
+        var input = requestWithoutApiKey();
+        var returnedPolicy = sendRequestToHandler(input);
+        var expectedPolicy = handler.createDenyAuthPolicy();
+        assertThat(returnedPolicy, is(equalTo(expectedPolicy)));
+
+        assertThat(appender.getMessages(), containsString(ForbiddenException.DEFAULT_MESSAGE));
+    }
+
+    private InputStream requestWithoutApiKey() throws JsonProcessingException {
+        return new HandlerRequestBuilder<Void>(JsonUtils.dtoObjectMapper)
+            .withOtherProperties(Map.of(METHOD_ARN_FIELD, this.inputMethodArn))
+            .build();
+    }
+
+    private AuthPolicy sendRequestToHandler(InputStream input) throws IOException {
+        handler.handleRequest(input, outputStream, CONTEXT);
+        var response = AuthorizerResponse.fromOutputStream(outputStream);
+        return response.getPolicyDocument();
+    }
+
+    private SecretsManagerClient setupSecretsClient() {
+        var secretsClient = mock(SecretsManagerClient.class);
+        when(secretsClient.getSecretValue(any(GetSecretValueRequest.class))).thenAnswer(invocation -> {
+            GetSecretValueRequest request = invocation.getArgument(0);
+            return constructSecretsClientResponse(request);
+        });
+        return secretsClient;
+    }
+
+    private GetSecretValueResponse constructSecretsClientResponse(GetSecretValueRequest request) {
+        if (request.secretId().equals(SECRET_NAME_SET_IN_TEST)) {
+            var secret = JsonUtils.dtoObjectMapper.createObjectNode();
+            secret.put(SECRET_KEY_SET_IN_TEST, expectedApiKey);
+            return GetSecretValueResponse.builder().secretString(secret.toString()).build();
+        }
+        return
+            GetSecretValueResponse.builder().build();
+    }
+
+    private InputStream requestWithValidApiKey() throws JsonProcessingException {
+        return requestWithApiKey(expectedApiKey);
+    }
+
+    private InputStream requestWithInvalidApiKey() throws JsonProcessingException {
+        return requestWithApiKey(randomString());
+    }
+
+    private InputStream requestWithApiKey(String s) throws JsonProcessingException {
+        return new HandlerRequestBuilder<Void>(JsonUtils.dtoObjectMapper)
+            .withHeaders(Map.of(HttpHeaders.AUTHORIZATION, s))
+            .withOtherProperties(Map.of(METHOD_ARN_FIELD, this.inputMethodArn))
+            .build();
+    }
+}

--- a/lambdaauthorizer/src/test/java/no/unit/commons/apigateway/authentication/RequestAuthorizerTest.java
+++ b/lambdaauthorizer/src/test/java/no/unit/commons/apigateway/authentication/RequestAuthorizerTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.net.HttpHeaders;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,7 +30,7 @@ public class RequestAuthorizerTest {
     public static final String SOME_PRINCIPAL_ID = "somePrincipalId";
     public static final String CORRECT_KEY = "SOME_KEY";
     public static final String DEFAULT_METHOD_ARN = "arn:aws:execute-api:eu-west-1:884807050265:2lcqynkwke/Prod/GET"
-        + "/service/users/orestis@unit.no";
+                                                    + "/service/users/orestis@unit.no";
     public static final String EXPECTED_RESOURCE = "arn:aws:execute-api:eu-west-1:884807050265:2lcqynkwke/Prod/*/*";
     public static final String METHOD_ARN_FIELD = "methodArn";
     public static final String UNEXPECTED_EXCEPTION_MESSAGE = "UnexpectedExceptionMessage";
@@ -153,8 +154,7 @@ public class RequestAuthorizerTest {
             .build();
     }
 
-    private InputStream createRequestStream(String apiKey)
-        throws com.fasterxml.jackson.core.JsonProcessingException {
+    public static InputStream createRequestStream(String apiKey) throws JsonProcessingException {
         Map<String, Object> methodArn = Map.of(METHOD_ARN_FIELD, DEFAULT_METHOD_ARN);
 
         return new HandlerRequestBuilder<Map<String, String>>(authorizerObjectMapper)
@@ -167,7 +167,7 @@ public class RequestAuthorizerTest {
         return new ByteArrayOutputStream();
     }
 
-    private Map<String, String> authHeaders(String apiKey) {
+    public static Map<String, String> authHeaders(String apiKey) {
         return Map.of(HttpHeaders.AUTHORIZATION, apiKey);
     }
 

--- a/secrets/src/main/java/nva/commons/secrets/ErrorReadingSecretException.java
+++ b/secrets/src/main/java/nva/commons/secrets/ErrorReadingSecretException.java
@@ -1,6 +1,6 @@
 package nva.commons.secrets;
 
-public class ErrorReadingSecretException extends Exception {
+public class ErrorReadingSecretException extends RuntimeException {
 
     public ErrorReadingSecretException() {
         super();

--- a/secrets/src/main/java/nva/commons/secrets/SecretsReader.java
+++ b/secrets/src/main/java/nva/commons/secrets/SecretsReader.java
@@ -42,7 +42,7 @@ public class SecretsReader {
      * @return the value for the specified key
      * @throws ErrorReadingSecretException when any error occurs.
      */
-    public String fetchSecret(String secretName, String secretKey) throws ErrorReadingSecretException {
+    public String fetchSecret(String secretName, String secretKey) {
 
         return attempt(() -> fetchSecretFromAws(secretName))
             .map(fetchResult -> extractApiKey(fetchResult, secretKey, secretName))
@@ -67,8 +67,7 @@ public class SecretsReader {
             .getSecretValue(GetSecretValueRequest.builder().secretId(secretName).build());
     }
 
-    private String extractApiKey(GetSecretValueResponse getSecretResult, String secretKey, String secretName)
-        throws ErrorReadingSecretException {
+    private String extractApiKey(GetSecretValueResponse getSecretResult, String secretKey, String secretName) {
 
         return Try.of(getSecretResult)
             .map(GetSecretValueResponse::secretString)


### PR DESCRIPTION
A "default" lambda authorizer for rest-api calls where the "Authorization" header is compared to a stored secret value.