### PR TITLE
NP-3544: move ScanDatabaseRequest from publication service to commons for reuse

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.18.6'
+version = '1.18.7'
 
 
 repositories {

--- a/eventhandlers/build.gradle
+++ b/eventhandlers/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     implementation libs.aws.sdk2.core
     implementation libs.aws.sdk.core
     implementation libs.jackson.databind
+    implementation libs.jackson.core
+    implementation libs.aws.sdk.dynamo
+    implementation libs.aws.sdk2.eventbridge
 
     testImplementation libs.bundles.testing
     testImplementation libs.bundles.logging

--- a/eventhandlers/src/main/java/no/unit/nva/events/EventsConfig.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/EventsConfig.java
@@ -1,0 +1,12 @@
+package no.unit.nva.events;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nva.commons.core.JsonUtils;
+
+public final class EventsConfig {
+
+    public static final ObjectMapper objectMapper = JsonUtils.dtoObjectMapper;
+
+    private EventsConfig() {
+    }
+}

--- a/eventhandlers/src/main/java/no/unit/nva/events/models/ScanDatabaseRequest.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/models/ScanDatabaseRequest.java
@@ -12,6 +12,12 @@ import nva.commons.core.JacocoGenerated;
 import nva.commons.core.JsonSerializable;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 
+/**
+ * Class that can be sent as an event to a lambda handler for scanning a page of a DynamoDB table. The {@code
+ * startMarker} is a scan start marker as required by the DynamoDb client. The {@code pageSize} is the number of the
+ * results the scan will return (max 1000). The {@code topic} is the event topic that the handler is listening for
+ * events.
+ */
 public class ScanDatabaseRequest implements JsonSerializable {
 
     public static final String START_MARKER = "startMarker";
@@ -57,6 +63,12 @@ public class ScanDatabaseRequest implements JsonSerializable {
         return startMarker;
     }
 
+    /**
+     * Utility method for creating easily the next scan request.
+     *
+     * @param newStartMarker the start marker for the next scan operation.
+     * @return a new ScanDatabaseRequest containing the the {@code newStartMarker}
+     */
     public ScanDatabaseRequest newScanDatabaseRequest(Map<String, AttributeValue> newStartMarker) {
         return new ScanDatabaseRequest(this.getTopic(), this.getPageSize(), newStartMarker);
     }

--- a/eventhandlers/src/main/java/no/unit/nva/events/models/ScanDatabaseRequest.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/models/ScanDatabaseRequest.java
@@ -1,0 +1,104 @@
+package no.unit.nva.events.models;
+
+import static no.unit.nva.events.EventsConfig.objectMapper;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import nva.commons.core.JacocoGenerated;
+import nva.commons.core.JsonSerializable;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+
+public class ScanDatabaseRequest implements JsonSerializable {
+
+    public static final String START_MARKER = "startMarker";
+    public static final String PAGE_SIZE = "pageSize";
+
+    public static final int DEFAULT_PAGE_SIZE = 700; // Choosing for safety 3/4 of max page size.
+    public static final int MAX_PAGE_SIZE = 1000;
+    public static final String TOPIC = "topic";
+    @JsonProperty(START_MARKER)
+    private final Map<String, AttributeValue> startMarker;
+    @JsonProperty(PAGE_SIZE)
+    private final int pageSize;
+    @JsonProperty(TOPIC)
+    private final String topic;
+
+    @JsonCreator
+    public ScanDatabaseRequest(
+        @JsonProperty(TOPIC) String topic,
+        @JsonProperty(PAGE_SIZE) int pageSize,
+        @JsonProperty(START_MARKER) Map<String, AttributeValue> startMarker) {
+        this.pageSize = pageSize;
+        this.startMarker = startMarker;
+        this.topic = topic;
+    }
+
+    public static ScanDatabaseRequest fromJson(String detail) throws JsonProcessingException {
+        return objectMapper.readValue(detail, ScanDatabaseRequest.class);
+    }
+
+    @JacocoGenerated
+    public String getTopic() {
+        return topic;
+    }
+
+    public int getPageSize() {
+        return pageSizeWithinLimits(pageSize)
+                   ? pageSize
+                   : DEFAULT_PAGE_SIZE;
+    }
+
+    @JacocoGenerated
+    public Map<String, AttributeValue> getStartMarker() {
+        return startMarker;
+    }
+
+    public ScanDatabaseRequest newScanDatabaseRequest(Map<String, AttributeValue> newStartMarker) {
+        return new ScanDatabaseRequest(this.getTopic(), this.getPageSize(), newStartMarker);
+    }
+
+    public PutEventsRequestEntry createNewEventEntry(
+        String eventBusName,
+        String detailType,
+        String invokedFunctionArn
+    ) {
+        return PutEventsRequestEntry
+            .builder()
+            .eventBusName(eventBusName)
+            .detail(this.toJsonString())
+            .detailType(detailType)
+            .resources(invokedFunctionArn)
+            .time(Instant.now())
+            .source(invokedFunctionArn)
+            .build();
+    }
+
+    @Override
+    @JacocoGenerated
+    public int hashCode() {
+        return Objects.hash(getStartMarker(), getPageSize(), getTopic());
+    }
+
+    @Override
+    @JacocoGenerated
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ScanDatabaseRequest)) {
+            return false;
+        }
+        ScanDatabaseRequest that = (ScanDatabaseRequest) o;
+        return getPageSize() == that.getPageSize()
+               && Objects.equals(getStartMarker(), that.getStartMarker())
+               && Objects.equals(getTopic(), that.getTopic());
+    }
+
+    private boolean pageSizeWithinLimits(int pageSize) {
+        return pageSize > 0 && pageSize <= MAX_PAGE_SIZE;
+    }
+}

--- a/eventhandlers/src/test/java/no/unit/nva/events/models/ScanDatabaseRequestTest.java
+++ b/eventhandlers/src/test/java/no/unit/nva/events/models/ScanDatabaseRequestTest.java
@@ -1,0 +1,43 @@
+package no.unit.nva.events.models;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Map;
+import no.unit.nva.events.EventsConfig;
+import org.junit.jupiter.api.Test;
+
+class ScanDatabaseRequestTest {
+
+    public static final String EVENT_TOPIC = "topic";
+
+    @Test
+    void shouldReturnAnEventBridgeEventWhereTheTopicIsSetInTheDetailBody() throws JsonProcessingException {
+        String expectedTopic = randomString();
+        var request = new ScanDatabaseRequest(expectedTopic, 100, null);
+        var event = request.createNewEventEntry(randomString(), randomString(), randomString());
+        var eventAsJson = EventsConfig.objectMapper.readTree(event.detail());
+        assertThat(eventAsJson.get(EVENT_TOPIC).textValue(), is(equalTo(expectedTopic)));
+    }
+
+    @Test
+    void shouldReturnScanRequestFromEventDetail() throws JsonProcessingException {
+        var originalRequest = new ScanDatabaseRequest(randomString(), randomInteger(), null);
+        var event = originalRequest.createNewEventEntry(randomString(), randomString(), randomString());
+        var reconstructedRequest = ScanDatabaseRequest.fromJson(event.detail());
+        assertThat(reconstructedRequest, is(equalTo(originalRequest)));
+    }
+
+    @Test
+    void shouldGenerateNewEventWithSameTopicAndPageSizer() {
+        var originalRequest = new ScanDatabaseRequest(randomString(), randomInteger(), null);
+        var expectedStartMarker = Map.of(randomString(), new AttributeValue(randomString()),
+                                         randomString(), new AttributeValue(randomString()));
+        var newRequest = originalRequest.newScanDatabaseRequest(expectedStartMarker);
+        assertThat(newRequest.getStartMarker(), is(equalTo(expectedStartMarker)));
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,8 +39,8 @@ aws-sdk2-secrets = { group = 'software.amazon.awssdk', name = 'secretsmanager', 
 aws-sdk2-urlconnection = { group = 'software.amazon.awssdk', name = 'url-connection-client', version.ref = 'awsSdk2' }
 
 aws-ion = { group = 'software.amazon.ion', name = 'ion-java', version.ref = 'awsIon' }
-aws-sdk-s3 = { group = 'software.amazon.awssdk', name = 's3', version.ref = 'awsSdk2' }
-aws-sdk-eventbridge = { group = 'software.amazon.awssdk', name = 'eventbridge', version.ref = 'awsSdk2' }
+aws-sdk2-s3 = { group = 'software.amazon.awssdk', name = 's3', version.ref = 'awsSdk2' }
+aws-sdk2-eventbridge = { group = 'software.amazon.awssdk', name = 'eventbridge', version.ref = 'awsSdk2' }
 aws-http-client-spi = { group = 'software.amazon.awssdk', name = 'http-client-spi', version = 'awsSdk2' }
 aws-apache-client = { group = 'software.amazon.awssdk', name = 'apache-client', version.ref = 'awsSdk2' }
 

--- a/nvatestutils/build.gradle
+++ b/nvatestutils/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     implementation libs.httpmime
 
     implementation libs.aws.sdk.sts
-    implementation libs.aws.sdk.s3
-    implementation libs.aws.sdk.eventbridge
+    implementation libs.aws.sdk2.s3
+    implementation libs.aws.sdk2.eventbridge
 
     implementation libs.bundles.jackson
     implementation libs.commons.validator

--- a/s3/build.gradle
+++ b/s3/build.gradle
@@ -5,7 +5,7 @@ plugins{
 
 dependencies {
     implementation project (":core")
-    implementation libs.aws.sdk.s3
+    implementation libs.aws.sdk2.s3
     implementation libs.aws.sdk2.core
     implementation libs.aws.ion
 


### PR DESCRIPTION
ScanDatabaseRequest is a class that is used currenty in Publication service for scanning/migrating/refreshing the publication. We need the same functionality in identity service and I thought we could reuse this event