### PR TITLE
NP-3574: empty value checker ignores both fields and classes

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.20.9'
+version = '1.20.10'
 
 repositories {
     mavenCentral()

--- a/nvatestutils/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
+++ b/nvatestutils/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
@@ -55,7 +55,21 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
 
     public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValuesIgnoringFields(Set<String> ignoreList) {
         DoesNotHaveEmptyValues<R> matcher = new DoesNotHaveEmptyValues<>();
+        initializeFieldNamesWhichWillBeIgnoredDuringChecking(ignoreList, matcher);
+        return matcher;
+    }
+
+    private static <R> void initializeFieldNamesWhichWillBeIgnoredDuringChecking(Set<String> ignoreList,
+                                                                                 DoesNotHaveEmptyValues<R> matcher) {
         matcher.ignoreFields = addFieldPathDelimiterToRootField(ignoreList);
+    }
+
+    public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValuesIgnoringFieldsAndClasses(
+        Set<Class<?>> ignoreClassesList,
+        Set<String> ignoreFieldsList) {
+        DoesNotHaveEmptyValues<R> matcher = new DoesNotHaveEmptyValues<>();
+        initializeClassesWhereRecursiveFieldCheckingWillStop(ignoreClassesList, matcher);
+        matcher.ignoreFields = addFieldPathDelimiterToRootField(ignoreFieldsList);
         return matcher;
     }
 

--- a/nvatestutils/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
+++ b/nvatestutils/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
@@ -59,17 +59,12 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
         return matcher;
     }
 
-    private static <R> void initializeFieldNamesWhichWillBeIgnoredDuringChecking(Set<String> ignoreList,
-                                                                                 DoesNotHaveEmptyValues<R> matcher) {
-        matcher.ignoreFields = addFieldPathDelimiterToRootField(ignoreList);
-    }
-
     public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValuesIgnoringFieldsAndClasses(
         Set<Class<?>> ignoreClassesList,
         Set<String> ignoreFieldsList) {
         DoesNotHaveEmptyValues<R> matcher = new DoesNotHaveEmptyValues<>();
         initializeClassesWhereRecursiveFieldCheckingWillStop(ignoreClassesList, matcher);
-        matcher.ignoreFields = addFieldPathDelimiterToRootField(ignoreFieldsList);
+        initializeFieldNamesWhichWillBeIgnoredDuringChecking(ignoreFieldsList, matcher);
         return matcher;
     }
 
@@ -98,6 +93,11 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
 
         description.appendText(EMPTY_FIELD_ERROR)
             .appendText(emptyFieldNames);
+    }
+
+    private static <R> void initializeFieldNamesWhichWillBeIgnoredDuringChecking(Set<String> ignoreList,
+                                                                                 DoesNotHaveEmptyValues<R> matcher) {
+        matcher.ignoreFields = addFieldPathDelimiterToRootField(ignoreList);
     }
 
     private static <R> void initializeClassesWhereRecursiveFieldCheckingWillStop(Set<Class<?>> ignoreList,

--- a/nvatestutils/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/nvatestutils/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -206,12 +206,12 @@ public class DoesNotHaveEmptyValuesTest {
 
     @Test
     void shouldReturnTrueWhenIgnoredFieldIsEmptyAndFieldsInIgnoredClassAreEmpty() {
-        WithBaseTypes withBaseTypes = new WithBaseTypes(EMPTY_STRING,
-                                                        NULL_INTEGER,
-                                                        Collections.emptyList(),
-                                                        Collections.emptyMap(),
-                                                        JsonUtils.dtoObjectMapper.createObjectNode());
-        ClassWithChildrenWithMultipleFields objectWithBothEmptyValuesAndClassWithEmptyValues =
+        var withBaseTypes = new WithBaseTypes(EMPTY_STRING,
+                                              NULL_INTEGER,
+                                              Collections.emptyList(),
+                                              Collections.emptyMap(),
+                                              JsonUtils.dtoObjectMapper.createObjectNode());
+        var objectWithBothEmptyValuesAndClassWithEmptyValues =
             new ClassWithChildrenWithMultipleFields(NULL_STRING, withBaseTypes, SAMPLE_INT);
         assertThatContainedObjectHasEmptyFields(withBaseTypes);
         assertThat(objectWithBothEmptyValuesAndClassWithEmptyValues, doesNotHaveEmptyValuesIgnoringFieldsAndClasses(


### PR DESCRIPTION
The hamcrest checker has two methods: one for ignoring specific fields (e.g., "doiRequest") and one for ignoring classes (e.g, "GregorianCalendar.class"). The new method does both at the same time