### PR TITLE
Apigatewayv2

### DIFF
--- a/apigateway/build.gradle
+++ b/apigateway/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 
     implementation libs.guava
     implementation libs.bundles.logging
+    implementation libs.aws.lambda.events
 
     implementation libs.jackson.core
     implementation libs.jackson.databind

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandlerV2.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandlerV2.java
@@ -1,0 +1,112 @@
+package nva.commons.apigateway;
+
+import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.util.Objects.isNull;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static nva.commons.core.attempt.Try.attempt;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TreeTraversingParser;
+import com.google.common.net.MediaType;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import no.unit.nva.commons.json.JsonUtils;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.core.Environment;
+import org.zalando.problem.Problem;
+import org.zalando.problem.Status;
+import org.zalando.problem.ThrowableProblem;
+
+public abstract class ApiGatewayHandlerV2<I, O>
+    implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final List<MediaType> DEFAULT_SUPPORTED_MEDIA_TYPES = List.of(JSON_UTF_8);
+    private static final String ALLOWED_ORIGIN = new Environment().readEnv("ALLOWED_ORIGIN");
+    private Class<I> iclass;
+    private Supplier<Map<String, String>> additionalSuccessHeadersSupplier;
+
+    protected ApiGatewayHandlerV2(Class<I> iclass) {
+        this.iclass = iclass;
+        additionalSuccessHeadersSupplier = Collections::emptyMap;
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
+        try {
+            var inputBody = parseBody(input.getBody());
+            var output = processInput(inputBody, input, context);
+            return new APIGatewayProxyResponseEvent()
+                .withBody(Optional.ofNullable(output).map(Object::toString).orElse(null))
+                .withStatusCode(getSuccessStatusCode(inputBody, output))
+                .withHeaders(getSuccessHeaders(input));
+        } catch (ApiGatewayException e) {
+            var problem = Problem.builder()
+                .withDetail(e.getMessage())
+                .withStatus(Status.valueOf(e.getStatusCode()))
+                .build();
+            return problemToApiGatewayResponse(problem);
+        } catch (Exception e) {
+            var problem = Problem.builder()
+                .withStatus(Status.valueOf(HTTP_INTERNAL_ERROR))
+                .withDetail("Internal error")
+                .build();
+            return problemToApiGatewayResponse(problem);
+        }
+    }
+
+    protected void addAdditionalSuccessHeaders(Supplier<Map<String, String>> additionalHeaders) {
+        this.additionalSuccessHeadersSupplier = Optional.ofNullable(additionalHeaders).orElse(Collections::emptyMap);
+    }
+
+    protected abstract Integer getSuccessStatusCode(I input, O output);
+
+    protected abstract O processInput(I body, APIGatewayProxyRequestEvent input, Context context)
+        throws ApiGatewayException;
+
+    protected List<MediaType> listSupportedMediaTypes() {
+        return DEFAULT_SUPPORTED_MEDIA_TYPES;
+    }
+
+    private Map<String, String> getSuccessHeaders(APIGatewayProxyRequestEvent input) {
+        Map<String, String> successHeaders = new HashMap<>(defaultHeaders(input));
+        successHeaders.putAll(additionalSuccessHeadersSupplier.get());
+        return successHeaders;
+    }
+
+    private Map<String, String> defaultHeaders(APIGatewayProxyRequestEvent input) {
+        Map<String, String> headers = new ConcurrentHashMap<>();
+        headers.put(ACCESS_CONTROL_ALLOW_ORIGIN, ALLOWED_ORIGIN);
+        return headers;
+    }
+
+    private APIGatewayProxyResponseEvent problemToApiGatewayResponse(ThrowableProblem problem) {
+        return new APIGatewayProxyResponseEvent().withStatusCode(problem.getStatus().getStatusCode())
+            .withBody(problem.toString());
+    }
+
+    private I parseBody(String body) {
+        if (isNull(body)) {
+            return null;
+        }
+        else if (String.class.equals(iclass)) {
+            return (I) body;
+        }
+        else {
+            return attempt(() -> dtoObjectMapper.readValue(body, iclass)).orElseThrow();
+        }
+    }
+
+   
+}

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandlerV2.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandlerV2.java
@@ -103,7 +103,7 @@ public abstract class ApiGatewayHandlerV2<I, O>
     }
 
     private ThrowableProblem createProblem(String message, Integer statusCode, Context context) {
-        Status status = Status.valueOf(statusCode);
+        var status = Status.valueOf(statusCode);
         return Problem.builder()
             .withDetail(message)
             .withTitle(status.getReasonPhrase())

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandlerV2.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandlerV2.java
@@ -1,20 +1,19 @@
 package nva.commons.apigateway;
 
 import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN;
-import static com.google.common.net.MediaType.JSON_UTF_8;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.util.Objects.isNull;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static nva.commons.apigateway.MediaTypes.DEFAULT_SUPPORTED_MEDIA_TYPES;
+import static nva.commons.apigateway.MediaTypes.MOST_PREFERRED_DEFAULT_MEDIA_TYPE;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.TreeTraversingParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -22,9 +21,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
-import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.apigateway.exceptions.RedirectException;
+import nva.commons.apigateway.exceptions.UnsupportedAcceptHeaderException;
 import nva.commons.core.Environment;
+import nva.commons.core.attempt.Try;
+import nva.commons.core.exceptions.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 import org.zalando.problem.ThrowableProblem;
@@ -32,9 +37,11 @@ import org.zalando.problem.ThrowableProblem;
 public abstract class ApiGatewayHandlerV2<I, O>
     implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final List<MediaType> DEFAULT_SUPPORTED_MEDIA_TYPES = List.of(JSON_UTF_8);
+    public static final String REQUEST_ID = "RequestId";
+    public static final String INTERNAL_ERROR_MESSAGE = "Internal error";
     private static final String ALLOWED_ORIGIN = new Environment().readEnv("ALLOWED_ORIGIN");
-    private Class<I> iclass;
+    private static final Logger logger = LoggerFactory.getLogger(ApiGatewayHandlerV2.class);
+    private final Class<I> iclass;
     private Supplier<Map<String, String>> additionalSuccessHeadersSupplier;
 
     protected ApiGatewayHandlerV2(Class<I> iclass) {
@@ -45,24 +52,20 @@ public abstract class ApiGatewayHandlerV2<I, O>
     @Override
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
         try {
-            var inputBody = parseBody(input.getBody());
+            logger.info("{}:{}", REQUEST_ID, context.getAwsRequestId());
+            var inputBody = attempt(() -> parseInput(input.getBody()))
+                .orElseThrow(this::handleInputParsingError);
             var output = processInput(inputBody, input, context);
-            return new APIGatewayProxyResponseEvent()
-                .withBody(Optional.ofNullable(output).map(Object::toString).orElse(null))
-                .withStatusCode(getSuccessStatusCode(inputBody, output))
-                .withHeaders(getSuccessHeaders(input));
-        } catch (ApiGatewayException e) {
-            var problem = Problem.builder()
-                .withDetail(e.getMessage())
-                .withStatus(Status.valueOf(e.getStatusCode()))
-                .build();
-            return problemToApiGatewayResponse(problem);
-        } catch (Exception e) {
-            var problem = Problem.builder()
-                .withStatus(Status.valueOf(HTTP_INTERNAL_ERROR))
-                .withDetail("Internal error")
-                .build();
-            return problemToApiGatewayResponse(problem);
+
+            return createSuccessfulResponse(input, inputBody, output);
+        } catch (ApiGatewayException exception) {
+            logger.error(ExceptionUtils.stackTraceInSingleLine(exception));
+            ThrowableProblem problem = createProblem(exception.getMessage(), exception.getStatusCode(), context);
+            return problemToApiGatewayResponse(problem, exception);
+        } catch (Exception exception) {
+            logger.error(ExceptionUtils.stackTraceInSingleLine(exception));
+            ThrowableProblem problem = createProblem(INTERNAL_ERROR_MESSAGE, HTTP_INTERNAL_ERROR, context);
+            return problemToApiGatewayResponse(problem, exception);
         }
     }
 
@@ -79,34 +82,88 @@ public abstract class ApiGatewayHandlerV2<I, O>
         return DEFAULT_SUPPORTED_MEDIA_TYPES;
     }
 
-    private Map<String, String> getSuccessHeaders(APIGatewayProxyRequestEvent input) {
-        Map<String, String> successHeaders = new HashMap<>(defaultHeaders(input));
+    protected Map<String, String> getFailureHeaders() {
+        var headers = new HashMap<>(defaultHeaders());
+        headers.put(HttpHeaders.CONTENT_TYPE, MediaTypes.APPLICATION_PROBLEM_JSON.toString());
+        return headers;
+    }
+
+    protected I parseInput(String body) throws JsonProcessingException {
+        if (isNull(body)) {
+            return null;
+        } else if (String.class.equals(iclass)) {
+            return (I) body;
+        } else {
+            return dtoObjectMapper.readValue(body, iclass);
+        }
+    }
+
+    private BadRequestException handleInputParsingError(Try<I> fail) {
+        return new BadRequestException(fail.getException().getMessage(), fail.getException());
+    }
+
+    private ThrowableProblem createProblem(String message, Integer statusCode, Context context) {
+        Status status = Status.valueOf(statusCode);
+        return Problem.builder()
+            .withDetail(message)
+            .withTitle(status.getReasonPhrase())
+            .withStatus(status)
+            .with(REQUEST_ID, context.getAwsRequestId())
+            .build();
+    }
+
+    private MediaType calculateContentTypeHeader(APIGatewayProxyRequestEvent requestEvent)
+        throws UnsupportedAcceptHeaderException {
+        return attemptToMatchAcceptHeadersToSupportedHeaders(requestEvent)
+            .orElseThrow(fail -> (UnsupportedAcceptHeaderException) fail.getException());
+    }
+
+    private Try<MediaType> attemptToMatchAcceptHeadersToSupportedHeaders(APIGatewayProxyRequestEvent requestEvent) {
+        return extractAcceptHeaders(requestEvent)
+            .map(attempt(mediaTypesString -> MediaTypes.parse(mediaTypesString, listSupportedMediaTypes())))
+            .orElse(Try.of(listSupportedMediaTypes().get(MOST_PREFERRED_DEFAULT_MEDIA_TYPE)));
+    }
+
+    private Optional<String> extractAcceptHeaders(APIGatewayProxyRequestEvent requestEvent) {
+        return Optional.ofNullable(requestEvent)
+            .map(APIGatewayProxyRequestEvent::getHeaders)
+            .map(headers -> headers.get(HttpHeaders.ACCEPT));
+    }
+
+    private APIGatewayProxyResponseEvent createSuccessfulResponse(APIGatewayProxyRequestEvent input,
+                                                                  I inputBody,
+                                                                  O output) throws UnsupportedAcceptHeaderException {
+        return new APIGatewayProxyResponseEvent()
+            .withBody(Optional.ofNullable(output).map(Object::toString).orElse(null))
+            .withStatusCode(getSuccessStatusCode(inputBody, output))
+            .withHeaders(getSuccessHeaders(input));
+    }
+
+    private Map<String, String> getSuccessHeaders(APIGatewayProxyRequestEvent input)
+        throws UnsupportedAcceptHeaderException {
+        var successHeaders = new ConcurrentHashMap<>(defaultHeaders());
+        var contentTypeHeader = calculateContentTypeHeader(input);
+        successHeaders.put(HttpHeaders.CONTENT_TYPE, contentTypeHeader.toString());
         successHeaders.putAll(additionalSuccessHeadersSupplier.get());
         return successHeaders;
     }
 
-    private Map<String, String> defaultHeaders(APIGatewayProxyRequestEvent input) {
+    private Map<String, String> defaultHeaders() {
         Map<String, String> headers = new ConcurrentHashMap<>();
         headers.put(ACCESS_CONTROL_ALLOW_ORIGIN, ALLOWED_ORIGIN);
         return headers;
     }
 
-    private APIGatewayProxyResponseEvent problemToApiGatewayResponse(ThrowableProblem problem) {
-        return new APIGatewayProxyResponseEvent().withStatusCode(problem.getStatus().getStatusCode())
-            .withBody(problem.toString());
-    }
+    private APIGatewayProxyResponseEvent problemToApiGatewayResponse(ThrowableProblem problem,
+                                                                     Exception exception) {
 
-    private I parseBody(String body) {
-        if (isNull(body)) {
-            return null;
+        var failureHeaders = getFailureHeaders();
+        if (exception instanceof RedirectException) {
+            failureHeaders.put(HttpHeaders.LOCATION, ((RedirectException) exception).getLocation().toString());
         }
-        else if (String.class.equals(iclass)) {
-            return (I) body;
-        }
-        else {
-            return attempt(() -> dtoObjectMapper.readValue(body, iclass)).orElseThrow();
-        }
+        return new APIGatewayProxyResponseEvent()
+            .withStatusCode(problem.getStatus().getStatusCode())
+            .withHeaders(failureHeaders)
+            .withBody(attempt(() -> dtoObjectMapper.writeValueAsString(problem)).orElseThrow());
     }
-
-   
 }

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandlerV2.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandlerV2.java
@@ -60,11 +60,11 @@ public abstract class ApiGatewayHandlerV2<I, O>
             return createSuccessfulResponse(input, inputBody, output);
         } catch (ApiGatewayException exception) {
             logger.error(ExceptionUtils.stackTraceInSingleLine(exception));
-            ThrowableProblem problem = createProblem(exception.getMessage(), exception.getStatusCode(), context);
+            var problem = createProblem(exception.getMessage(), exception.getStatusCode(), context);
             return problemToApiGatewayResponse(problem, exception);
         } catch (Exception exception) {
             logger.error(ExceptionUtils.stackTraceInSingleLine(exception));
-            ThrowableProblem problem = createProblem(INTERNAL_ERROR_MESSAGE, HTTP_INTERNAL_ERROR, context);
+            var problem = createProblem(INTERNAL_ERROR_MESSAGE, HTTP_INTERNAL_ERROR, context);
             return problemToApiGatewayResponse(problem, exception);
         }
     }

--- a/apigateway/src/main/java/nva/commons/apigateway/MediaTypes.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/MediaTypes.java
@@ -25,7 +25,7 @@ public final class MediaTypes {
     public static MediaType parse(String mediaType, List<MediaType> supportedMediaTypes)
         throws UnsupportedAcceptHeaderException {
         var mediaTypeString = StringUtils.removeWhiteSpaces(mediaType);
-        MediaType mostPreferredMediaType = mostPreferredMediaType(supportedMediaTypes);
+        var mostPreferredMediaType = mostPreferredMediaType(supportedMediaTypes);
         var requestedMediaTypes = parseRequestMediaTypes(mediaTypeString, mostPreferredMediaType);
         var result = findFirstMatchingHeader(supportedMediaTypes, requestedMediaTypes);
         return result.orElseThrow(() -> new UnsupportedAcceptHeaderException(requestedMediaTypes, supportedMediaTypes));

--- a/apigateway/src/main/java/nva/commons/apigateway/MediaTypes.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/MediaTypes.java
@@ -1,14 +1,71 @@
 package nva.commons.apigateway;
 
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static nva.commons.core.attempt.Try.attempt;
 import com.google.common.net.MediaType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import nva.commons.apigateway.exceptions.UnsupportedAcceptHeaderException;
+import nva.commons.core.StringUtils;
+import nva.commons.core.attempt.Try;
 
 public final class MediaTypes {
 
     public static final MediaType APPLICATION_JSON_LD = MediaType.create("application", "ld+json");
     public static final MediaType APPLICATION_PROBLEM_JSON = MediaType.create("application", "problem+json");
-
+    public static final String ACCEPT_HEADER_VALUES_DELIMITER = ",";
+    public static final List<MediaType> DEFAULT_SUPPORTED_MEDIA_TYPES = List.of(JSON_UTF_8.withoutParameters());
+    public static final int MOST_PREFERRED_DEFAULT_MEDIA_TYPE = 0;
 
     private MediaTypes() {
     }
 
+    public static MediaType parse(String mediaType, List<MediaType> supportedMediaTypes)
+        throws UnsupportedAcceptHeaderException {
+        var mediaTypeString = StringUtils.removeWhiteSpaces(mediaType);
+        MediaType mostPreferredMediaType = mostPreferredMediaType(supportedMediaTypes);
+        var requestedMediaTypes = parseRequestMediaTypes(mediaTypeString, mostPreferredMediaType);
+        var result = findFirstMatchingHeader(supportedMediaTypes, requestedMediaTypes);
+        return result.orElseThrow(() -> new UnsupportedAcceptHeaderException(requestedMediaTypes, supportedMediaTypes));
+    }
+
+    private static MediaType mostPreferredMediaType(List<MediaType> supportedMediaTypes) {
+        return supportedMediaTypes.get(MOST_PREFERRED_DEFAULT_MEDIA_TYPE);
+    }
+
+    private static Optional<MediaType> findFirstMatchingHeader(List<MediaType> supportedMediaTypes,
+                                                               List<MediaType> requestedMediaTypes) {
+        return requestedMediaTypes.stream()
+            .filter(mediaType -> isSupported(mediaType, supportedMediaTypes))
+            .findFirst();
+    }
+
+    private static boolean isSupported(MediaType mediaType, List<MediaType> supportedMediaTypes) {
+        return supportedMediaTypes
+            .stream()
+            .map(MediaType::withoutParameters)
+            .anyMatch(supported -> supported.is(mediaType.withoutParameters()));
+    }
+
+    private static List<MediaType> parseRequestMediaTypes(String cleanedMediaType, MediaType mostPreferedMediaType) {
+        return attempt(() -> cleanedMediaType.split(ACCEPT_HEADER_VALUES_DELIMITER))
+            .stream()
+            .flatMap(Arrays::stream)
+            .map(attempt(MediaTypes::parseHeader))
+            .map(Try::orElseThrow)
+            .map(mediaType -> mapAnyContentTypeToDefault(mediaType, mostPreferedMediaType))
+            .collect(Collectors.toList());
+    }
+
+    private static MediaType parseHeader(String headerString) {
+        return MediaType.parse(headerString);
+    }
+
+    private static MediaType mapAnyContentTypeToDefault(MediaType header, MediaType mostPreferredSupportedMediaType) {
+        return MediaType.ANY_TYPE.is(header)
+                   ? mostPreferredSupportedMediaType
+                   : header;
+    }
 }

--- a/apigateway/src/main/resources/log4j2.xml
+++ b/apigateway/src/main/resources/log4j2.xml
@@ -5,7 +5,7 @@
   <Appenders>
     <Appender type="Lambda" name="Lambda">
       <PatternLayout>
-        <pattern>%d{ISO8601_OFFSET_DATE_TIME_HHCMM} %X{AWSRequestId} %-5p %m%n</pattern>
+        <pattern>%d{ISO8601_OFFSET_DATE_TIME_HHCMM} %X{AWSRequestId} %-5p %c{1.}:%L - %m%n</pattern>
       </PatternLayout>
     </Appender>
 

--- a/apigateway/src/main/resources/log4j2.xml
+++ b/apigateway/src/main/resources/log4j2.xml
@@ -5,7 +5,7 @@
   <Appenders>
     <Appender type="Lambda" name="Lambda">
       <PatternLayout>
-        <pattern>%d{ISO8601_OFFSET_DATE_TIME_HHCMM} %X{AWSRequestId} %-5p %c{1.}:%L - %m%n</pattern>
+        <pattern>%d{ISO8601_OFFSET_DATE_TIME_HHCMM} %X{AWSRequestId} %-5p %m%n</pattern>
       </PatternLayout>
     </Appender>
 

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
@@ -161,7 +161,7 @@ public class ApiGatewayHandlerTest {
         throws IOException {
         Handler handler = handlerThatOverridesListSupportedMediaTypes();
 
-        InputStream input = requestWithAcceptHeader(MediaTypes.APPLICATION_JSON_LD.toString());
+        InputStream input = requestWithAcceptHeader("application/ld+json");
 
         GatewayResponse<String> response = getStringResponse(input, handler);
 

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerV2Test.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerV2Test.java
@@ -1,33 +1,55 @@
 package nva.commons.apigateway;
 
-import static no.unit.nva.testutils.RandomDataGenerator.randomJson;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static nva.commons.apigateway.ApiGatewayHandlerV2.INTERNAL_ERROR_MESSAGE;
+import static nva.commons.apigateway.ApiGatewayHandlerV2.REQUEST_ID;
+import static nva.commons.apigateway.MediaTypes.APPLICATION_PROBLEM_JSON;
+import static nva.commons.core.attempt.Try.attempt;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.management.modelmbean.XMLParseException;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.stubs.FakeContext;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.apigateway.exceptions.TestException;
 import nva.commons.apigateway.exceptions.UnsupportedAcceptHeaderException;
 import nva.commons.apigateway.testutils.HandlerV2;
+import nva.commons.apigateway.testutils.RedirectHandlerV2;
 import nva.commons.apigateway.testutils.RequestBody;
+import nva.commons.logutils.LogUtils;
+import nva.commons.logutils.TestAppender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.zalando.problem.Problem;
+import org.zalando.problem.Status;
 
 public class ApiGatewayHandlerV2Test {
 
@@ -53,17 +75,28 @@ public class ApiGatewayHandlerV2Test {
     }
 
     @Test
+    void handleRequestReturnsContentTypeJsonOnAcceptWildcard()
+        throws IOException {
+        var handler = handlerThatOverridesListSupportedMediaTypes();
+        var input = requestWithAcceptHeader(MediaType.ANY_TYPE.toString());
+        var response = handler.handleRequest(input, context);
+
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+        assertThat(response.getHeaders().get(CONTENT_TYPE), is(equalTo(MediaType.JSON_UTF_8.toString())));
+    }
+
+    @Test
     @DisplayName("ApiGatewayHandler has a constructor with input class as only parameter")
     void apiGatewayHandlerHasAConstructorWithInputClassAsOnlyParameter() {
         ApiGatewayHandlerV2<String, String> handler = new ApiGatewayHandlerV2<>(String.class) {
             @Override
-            protected String processInput(String input, APIGatewayProxyRequestEvent requestInfo, Context context) {
-                return null;
+            protected Integer getSuccessStatusCode(String input, String output) {
+                return HttpURLConnection.HTTP_OK;
             }
 
             @Override
-            protected Integer getSuccessStatusCode(String input, String output) {
-                return HttpURLConnection.HTTP_OK;
+            protected String processInput(String input, APIGatewayProxyRequestEvent requestInfo, Context context) {
+                return null;
             }
         };
     }
@@ -87,451 +120,323 @@ public class ApiGatewayHandlerV2Test {
     })
     void handleRequestShouldReturnUnsupportedMediaTypeOnUnsupportedAcceptHeader(String mediaType)
         throws IOException {
-        APIGatewayProxyRequestEvent input = requestWithAcceptHeader(mediaType);
-
+        var input = requestWithAcceptHeader(mediaType);
         var response = handler.handleRequest(input, context);
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNSUPPORTED_TYPE)));
-        String expectedMessage = getUnsupportedMediaTypeErrorMessage(mediaType);
+        var expectedMessage = getUnsupportedMediaTypeErrorMessage(mediaType);
         assertThat(response.getBody(), containsString(expectedMessage));
     }
 
-    //
-    //    @ParameterizedTest(name = "handleRequest should return OK when input is {0}")
-    //    @ValueSource(strings = {
-    //        "*/*",
-    //        "application/json",
-    //        "application/json; charset=UTF-8",
-    //        "text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8"
-    //    })
-    //    public void handleRequestShouldReturnOkOnSupportedAcceptHeader(String mediaType) throws IOException {
-    //        InputStream input = requestWithAcceptHeader(mediaType);
-    //
-    //        GatewayResponse<String> response = getStringResponse(input, handler);
-    //
-    //        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-    //    }
-    //
-    //    @Test
-    //    public void handleRequestReturnsContentTypeJsonOnAcceptWildcard()
-    //        throws IOException {
-    //        Handler handler = handlerThatOverridesListSupportedMediaTypes();
-    //
-    //        InputStream input = requestWithAcceptHeader(MediaType.ANY_TYPE.toString());
-    //
-    //        GatewayResponse<String> response = getStringResponse(input, handler);
-    //
-    //        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-    //        assertThat(response.getHeaders().get(CONTENT_TYPE), is(equalTo(MediaType.JSON_UTF_8.toString())));
-    //    }
-    //
-    //    @Test
-    //    public void handleRequestReturnsContentTypeJsonLdOnAcceptJsonLd()
-    //        throws IOException {
-    //        Handler handler = handlerThatOverridesListSupportedMediaTypes();
-    //
-    //        InputStream input = requestWithAcceptHeader(MediaTypes.APPLICATION_JSON_LD.toString());
-    //
-    //        GatewayResponse<String> response = getStringResponse(input, handler);
-    //
-    //        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-    //        assertThat(response.getHeaders().get(CONTENT_TYPE), is(equalTo(MediaTypes.APPLICATION_JSON_LD.toString
-    //        ())));
-    //    }
-    //
-    //    @Test
-    //    @DisplayName("handleRequest should have available the request path")
-    //    public void handleRequestShouldHaveAvailableTheRequestPath() throws IOException {
-    //        InputStream input = requestWithHeadersAndPath();
-    //
-    //        getStringResponse(input, handler);
-    //
-    //        String actualPath = handler.getPath();
-    //        JsonNode expectedHeaders = createHeaders();
-    //        expectedHeaders.fieldNames().forEachRemaining(expectedHeader -> assertThat(actualPath, is(equalTo(PATH)
-    //        )));
-    //    }
-    //
-    //    @Test
-    //    @DisplayName("handleRequest allows response headers depended on input")
-    //    public void apiGatewayHandlerAllowsResponseHeadersDependedOnInput() throws IOException {
-    //        InputStream input = requestWithHeadersAndPath();
-    //        GatewayResponse<String> response = getStringResponse(input, handler);
-    //        assertTrue(response.getHeaders().containsKey(HttpHeaders.WARNING));
-    //    }
-    //
-    //    @Test
-    //    public void handleRequestDoesNotThrowExceptionOnUnknownFieldsInRequestInfo() throws IOException {
-    //        InputStream input = IoUtils.inputStreamFromResources(EVENT_WITH_UNKNOWN_REQUEST_INFO);
-    //
-    //        GatewayResponse<RequestBody> response = getResponse(RequestBody.class, input, handler);
-    //        RequestBody body = response.getBodyObject(RequestBody.class);
-    //
-    //        String expectedValueForField1 = "value1";
-    //        String expectedValueForField2 = "value2";
-    //        assertThat(body.getField1(), containsString(expectedValueForField1));
-    //        assertThat(body.getField2(), containsString(expectedValueForField2));
-    //    }
-    //
-    //    @Test
-    //    @DisplayName("Logger logs the whole exception stacktrace when an exception has occurred 2")
-    //    public void loggerLogsTheWholeExceptionStackTraceWhenAnExceptionHasOccurred() throws IOException {
-    //        TestAppender appender = LogUtils.getTestingAppenderForRootLogger();
-    //        Handler handler = handlerThatThrowsExceptions();
-    //        handler.handleRequest(requestWithHeadersAndPath(), outputStream(), context);
-    //
-    //        String logs = appender.getMessages();
-    //
-    //        assertThat(logs, containsString(URISyntaxException.class.getName()));
-    //        assertThat(logs, containsString(XMLParseException.class.getName()));
-    //        assertThat(logs, containsString(TestException.class.getName()));
-    //        assertThat(logs, containsString(BOTTOM_EXCEPTION_MESSAGE));
-    //        assertThat(logs, containsString(MIDDLE_EXCEPTION_MESSAGE));
-    //        assertThat(logs, containsString(TOP_EXCEPTION_MESSAGE));
-    //    }
-    //
-    //    @Test
-    //    @DisplayName("Logger logs the whole exception stacktrace when an exception has occurred")
-    //    public void loggerLogsTheWholeExceptionStackTraceWhenAnUncheckedExceptionHasOccurred() throws IOException {
-    //        TestAppender appender = LogUtils.getTestingAppenderForRootLogger();
-    //        Handler handler = handlerThatThrowsUncheckedExceptions();
-    //
-    //        handler.handleRequest(requestWithHeadersAndPath(), outputStream(), context);
-    //
-    //        String logs = appender.getMessages();
-    //
-    //        assertThat(logs, containsString(IllegalStateException.class.getName()));
-    //        assertThat(logs, containsString(IllegalArgumentException.class.getName()));
-    //        assertThat(logs, containsString(IllegalCallerException.class.getName()));
-    //        assertThat(logs, containsString(BOTTOM_EXCEPTION_MESSAGE));
-    //    }
-    //
-    //    @Test
-    //    @DisplayName("Handler does not reveal information for runtime exceptions")
-    //    public void handlerDoesNotRevealInformationForRuntimeExceptions() throws IOException {
-    //        Handler handler = handlerThatThrowsUncheckedExceptions();
-    //        ByteArrayOutputStream outputStream = outputStream();
-    //        handler.handleRequest(requestWithHeaders(), outputStream, context);
-    //        Problem problem = getProblemFromFailureResponse(outputStream);
-    //        String details = problem.getDetail();
-    //        assertThat(details, not(containsString(BOTTOM_EXCEPTION_MESSAGE)));
-    //        assertThat(details, not(containsString(MIDDLE_EXCEPTION_MESSAGE)));
-    //        assertThat(details, not(containsString(TOP_EXCEPTION_MESSAGE)));
-    //        assertThat(details, containsString(
-    //            ApiGatewayHandler.MESSAGE_FOR_RUNTIME_EXCEPTIONS_HIDING_IMPLEMENTATION_DETAILS_TO_API_CLIENTS));
-    //    }
-    //
-    //    @Test
-    //    @DisplayName("Failure message contains exception message and status code when an Exception is thrown")
-    //    public void failureMessageContainsExceptionMessageAndStatusCodeWhenAnExceptionIsThrown()
-    //        throws IOException {
-    //        Handler handler = handlerThatThrowsExceptions();
-    //
-    //        GatewayResponse<Problem> responseParsing = getProblemResponse(requestWithHeadersAndPath(), handler);
-    //
-    //        Problem problem = responseParsing.getBodyObject(Problem.class);
-    //        assertThat(problem.getDetail(), containsString(TOP_EXCEPTION_MESSAGE));
-    //        assertThat(problem.getTitle(), containsString(Status.NOT_FOUND.getReasonPhrase()));
-    //
-    //        assertThat(problem.getParameters().get(REQUEST_ID), is(equalTo(SOME_REQUEST_ID)));
-    //        assertThat(problem.getStatus(), is(Status.NOT_FOUND));
-    //    }
-    //
-    //    @Test
-    //    @DisplayName("Failure message contains application/problem+json ContentType when an Exception is thrown")
-    //    public void failureMessageContainsApplicationProblemJsonContentTypeWhenExceptionIsThrown()
-    //        throws IOException {
-    //        Handler handler = handlerThatThrowsExceptions();
-    //
-    //        GatewayResponse<Problem> responseParsing = getProblemResponse(requestWithHeadersAndPath(), handler);
-    //
-    //        assertThat(responseParsing.getHeaders().get(CONTENT_TYPE), is(equalTo(APPLICATION_PROBLEM_JSON.toString
-    //        ())));
-    //    }
-    //
-    //    @Test
-    //    @DisplayName("getFailureStatusCode sets the status code to the ApiGatewayResponse")
-    //    public void getFailureStatusCodeSetsTheStatusCodeToTheApiGatewayResponse() throws IOException {
-    //        Handler handler = handlerThatOverridesGetFailureStatusCode();
-    //
-    //        GatewayResponse<Problem> response = getProblemResponse(anyRequest(), handler);
-    //
-    //        assertThat(response.getStatusCode(), is(equalTo(OVERRIDDEN_STATUS_CODE)));
-    //        assertThat(response.getBodyObject(Problem.class).getStatus().getStatusCode(),
-    //                   is(equalTo(OVERRIDDEN_STATUS_CODE)));
-    //    }
-    //
-    //    @Test
-    //    @DisplayName("getFailureStatusCode returns by default the status code of the ApiGatewayException")
-    //    public void getFailureStatusCodeReturnsByDefaultTheStatusCodeOfTheApiGatewayException() throws IOException {
-    //        Handler handler = handlerThatThrowsExceptions();
-    //
-    //        GatewayResponse<Problem> response = getProblemResponse(anyRequest(), handler);
-    //
-    //        assertThat(response.getStatusCode(), is(equalTo(TestException.ERROR_STATUS_CODE)));
-    //        assertThat(response.getBodyObject(Problem.class).getStatus().getStatusCode(),
-    //                   is(equalTo(TestException.ERROR_STATUS_CODE)));
-    //    }
-    //
-    //    @Test
-    //    public void handlerLogsRequestIdForEveryRequest() throws IOException {
-    //        var appender = LogUtils.getTestingAppender(RestRequestHandler.class);
-    //        var output = outputStream();
-    //        var contextWithRequestId = new FakeContext();
-    //        var expectedRequestId = contextWithRequestId.getAwsRequestId();
-    //        handler.handleRequest(requestWithHeadersAndPath(), output, contextWithRequestId);
-    //        assertThat(appender.getMessages(), containsString(expectedRequestId));
-    //    }
-    //
-    //    @Test
-    //    public void itReturnsResponseWithPopulatedFieldsAndBothEmptyAndNonEmptyLists() throws IOException {
-    //        var output = outputStream();
-    //        InputStream input = requestWithBodyWithEmptyFields();
-    //        handler.handleRequest(input, output, context);
-    //        GatewayResponse<JsonNode> response = GatewayResponse.fromOutputStream(output);
-    //        JsonNode jsonNode = response.getBodyObject(JsonNode.class);
-    //        String nullField = RequestBody.FIELD2;
-    //        String presentField = RequestBody.FIELD1;
-    //        assertThat(jsonNode.has(presentField), is(true));
-    //        assertThat(jsonNode.has(nullField), is(false));
-    //        assertThat(jsonNode.has(RequestBody.EMPTY_LIST), is(true));
-    //        assertThat(jsonNode.get(RequestBody.EMPTY_LIST), is(instanceOf(ArrayNode.class)));
-    //    }
-    //
-    //    @Test
-    //    public void handlerReturnsBadRequestWhenInputParsingFails() throws IOException {
-    //        String expectedMessage = "Expected error message when parsing fails";
-    //        Handler handler = handlerFailingWhenParsing(expectedMessage);
-    //        InputStream input = requestWithHeadersAndPath();
-    //        GatewayResponse<Problem> response = getProblemResponse(input, handler);
-    //        Problem problem = response.getBodyObject(Problem.class);
-    //
-    //        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
-    //        assertThat(problem.getDetail(), containsString(expectedMessage));
-    //    }
-    //
-    //    @Test
-    //    void handlerSerializesBodyWithNonDefaultSerializationWhenDefaultSerializerIsOverridden() throws IOException {
-    //        ObjectMapper spiedMapper = spy(defaultRestObjectMapper);
-    //        var handler = new Handler(spiedMapper);
-    //        var inputStream = requestWithHeaders();
-    //        var outputStream = outputStream();
-    //        handler.handleRequest(inputStream, outputStream, context);
-    //        verify(spiedMapper, atLeast(1)).writeValueAsString(any());
-    //    }
-    //
-    //    @Test
-    //    void handlerSendsRedirectionWhenItReceivesARedirectException() throws IOException {
-    //        var expectedRedirectLocation = randomUri();
-    //        var expectedRedirectStatusCode = HttpURLConnection.HTTP_SEE_OTHER;
-    //        var handler = new RedirectHandler(expectedRedirectLocation, expectedRedirectStatusCode);
-    //        var request = requestWithHeaders(Map.of(HttpHeaders.ACCEPT, MediaType.HTML_UTF_8.toString()));
-    //        var response = getResponse(Void.class, request, handler);
-    //        assertThat(response.getStatusCode(), is(equalTo(expectedRedirectStatusCode)));
-    //        assertThat(response.getHeaders(), hasEntry(HttpHeaders.LOCATION, expectedRedirectLocation.toString()));
-    //    }
-    //
+    @ParameterizedTest(name = "handleRequest should return OK when input is {0}")
+    @ValueSource(strings = {
+        "*/*",
+        "application/json",
+        "application/json; charset=UTF-8",
+        "text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8"
+    })
+    void handleRequestShouldReturnOkOnSupportedAcceptHeader(String mediaType) throws IOException {
+        var input = requestWithAcceptHeader(mediaType);
+
+        var response = handler.handleRequest(input, context);
+
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+    }
+
+    @Test
+    void handleRequestReturnsContentTypeJsonLdOnAcceptJsonLd()
+        throws IOException {
+        HandlerV2 handler = handlerThatOverridesListSupportedMediaTypes();
+
+        var input = requestWithAcceptHeader(MediaTypes.APPLICATION_JSON_LD.toString());
+
+        var response = handler.handleRequest(input, context);
+
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+        assertThat(response.getHeaders().get(CONTENT_TYPE), is(equalTo(MediaTypes.APPLICATION_JSON_LD.toString())));
+    }
+
+    @Test
+    @DisplayName("handleRequest should have available the request path")
+    void handleRequestShouldHaveAvailableTheRequestPath() {
+        var input = requestWithHeadersAndPath();
+
+        var response = handler.handleRequest(input, context);
+
+        String actualPath = handler.getPath();
+        var expectedHeaders = createHeaders();
+        expectedHeaders.keySet().forEach(expectedHeader -> assertThat(actualPath, is(equalTo(PATH))));
+    }
+
+    @Test
+    @DisplayName("handleRequest allows response headers depended on input")
+    void apiGatewayHandlerAllowsResponseHeadersDependedOnInput() {
+        var input = requestWithHeadersAndPath();
+        var response = handler.handleRequest(input, context);
+        assertThat(response.getHeaders(), hasKey(HttpHeaders.WARNING));
+    }
+
+    @Test
+    @DisplayName("Logger logs the whole exception stacktrace when an exception has occurred 2")
+    void loggerLogsTheWholeExceptionStackTraceWhenAnExceptionHasOccurred() {
+        TestAppender appender = LogUtils.getTestingAppenderForRootLogger();
+        HandlerV2 handler = handlerThatThrowsExceptions();
+        handler.handleRequest(requestWithHeadersAndPath(), context);
+
+        String logs = appender.getMessages();
+
+        assertThat(logs, containsString(URISyntaxException.class.getName()));
+        assertThat(logs, containsString(XMLParseException.class.getName()));
+        assertThat(logs, containsString(TestException.class.getName()));
+        assertThat(logs, containsString(BOTTOM_EXCEPTION_MESSAGE));
+        assertThat(logs, containsString(MIDDLE_EXCEPTION_MESSAGE));
+        assertThat(logs, containsString(TOP_EXCEPTION_MESSAGE));
+    }
+
+    @Test
+    @DisplayName("Logger logs the whole exception stacktrace when an exception has occurred")
+    void loggerLogsTheWholeExceptionStackTraceWhenAnUncheckedExceptionHasOccurred() {
+        TestAppender appender = LogUtils.getTestingAppenderForRootLogger();
+        HandlerV2 handler = handlerThatThrowsUncheckedExceptions();
+
+        handler.handleRequest(requestWithHeadersAndPath(), context);
+
+        String logs = appender.getMessages();
+
+        assertThat(logs, containsString(IllegalStateException.class.getName()));
+        assertThat(logs, containsString(IllegalArgumentException.class.getName()));
+        assertThat(logs, containsString(IllegalCallerException.class.getName()));
+        assertThat(logs, containsString(BOTTOM_EXCEPTION_MESSAGE));
+    }
+
+    @Test
+    @DisplayName("Handler does not reveal information for runtime exceptions")
+    void handlerDoesNotRevealInformationForRuntimeExceptions() {
+        HandlerV2 handler = handlerThatThrowsUncheckedExceptions();
+
+        var response = handler.handleRequest(requestWithHeaders(), context);
+        Problem problem = extractProblemFromFailureResponse(response);
+        String details = problem.getDetail();
+        assertThat(details, not(containsString(BOTTOM_EXCEPTION_MESSAGE)));
+        assertThat(details, not(containsString(MIDDLE_EXCEPTION_MESSAGE)));
+        assertThat(details, not(containsString(TOP_EXCEPTION_MESSAGE)));
+        assertThat(details, containsString(INTERNAL_ERROR_MESSAGE));
+    }
+
+    @Test
+    @DisplayName("Failure message contains exception message and status code when an Exception is thrown")
+    void failureMessageContainsExceptionMessageAndStatusCodeWhenAnExceptionIsThrown()
+        throws IOException {
+        var handler = handlerThatThrowsExceptions();
+
+        var response = handler.handleRequest(requestWithHeadersAndPath(), context);
+
+        Problem problem = extractProblemFromFailureResponse(response);
+        assertThat(problem.getDetail(), containsString(TOP_EXCEPTION_MESSAGE));
+        assertThat(problem.getTitle(), containsString(Status.NOT_FOUND.getReasonPhrase()));
+
+        assertThat(problem.getParameters().get(REQUEST_ID), is(equalTo(SOME_REQUEST_ID)));
+        assertThat(problem.getStatus(), is(Status.NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("Failure message contains application/problem+json ContentType when an Exception is thrown")
+    void failureMessageContainsApplicationProblemJsonContentTypeWhenExceptionIsThrown()
+        throws IOException {
+        var handler = handlerThatThrowsExceptions();
+        var response = handler.handleRequest(requestWithHeadersAndPath(), context);
+        assertThat(response.getHeaders().get(CONTENT_TYPE), is(equalTo(APPLICATION_PROBLEM_JSON.toString())));
+    }
+
+    @Test
+    @DisplayName("getFailureStatusCode returns by default the status code of the ApiGatewayException")
+    void getFailureStatusCodeReturnsTheStatusCodeOfTheApiGatewayException() {
+        HandlerV2 handler = handlerThatThrowsExceptions();
+
+        var response = handler.handleRequest(requestWithHeaders(), context);
+        var problem = extractProblemFromFailureResponse(response);
+        assertThat(response.getStatusCode(), is(equalTo(TestException.ERROR_STATUS_CODE)));
+        assertThat(problem.getStatus().getStatusCode(), is(equalTo(TestException.ERROR_STATUS_CODE)));
+    }
+
+    @Test
+    void handlerLogsRequestIdForEveryRequest() {
+        var appender = LogUtils.getTestingAppender(ApiGatewayHandlerV2.class);
+        var contextWithRequestId = new FakeContext();
+        var expectedRequestId = contextWithRequestId.getAwsRequestId();
+        handler.handleRequest(requestWithHeadersAndPath(), contextWithRequestId);
+        assertThat(appender.getMessages(), containsString(expectedRequestId));
+    }
+
+    @Test
+    void itReturnsResponseWithPopulatedFieldsAndBothEmptyAndNonEmptyLists() throws IOException {
+
+        var input = requestWithBodyWithEmptyFields();
+        var response = handler.handleRequest(input, context);
+        JsonNode responseObject = JsonUtils.dtoObjectMapper.readTree(response.getBody());
+        String nullField = RequestBody.FIELD2;
+        String presentField = RequestBody.FIELD1;
+        assertThat(responseObject.has(presentField), is(true));
+        assertThat(responseObject.has(nullField), is(false));
+        assertThat(responseObject.has(RequestBody.EMPTY_LIST), is(true));
+        assertThat(responseObject.get(RequestBody.EMPTY_LIST), is(instanceOf(ArrayNode.class)));
+    }
+
+    @Test
+    void handlerReturnsBadRequestWhenInputParsingFails() {
+        String expectedMessage = "Expected error message when parsing fails";
+        HandlerV2 handler = handlerFailingWhenParsing(expectedMessage);
+        var input = requestWithHeadersAndPath();
+        var response = handler.handleRequest(input, context);
+        Problem problem = extractProblemFromFailureResponse(response);
+
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
+        assertThat(problem.getDetail(), containsString(expectedMessage));
+    }
+
+    @Test
+    void handlerSendsRedirectionWhenItReceivesARedirectException() {
+        var expectedRedirectLocation = randomUri();
+        var expectedRedirectStatusCode = HttpURLConnection.HTTP_SEE_OTHER;
+        var handler = new RedirectHandlerV2(expectedRedirectLocation, expectedRedirectStatusCode);
+        var request = requestWithHeaders(Map.of(HttpHeaders.ACCEPT, MediaType.HTML_UTF_8.toString()));
+        var response = handler.handleRequest(request, context);
+        assertThat(response.getStatusCode(), is(equalTo(expectedRedirectStatusCode)));
+        assertThat(response.getHeaders(), hasEntry(HttpHeaders.LOCATION, expectedRedirectLocation.toString()));
+    }
+
     private String getUnsupportedMediaTypeErrorMessage(String mediaType) {
         return UnsupportedAcceptHeaderException.createMessage(
             List.of(MediaType.parse(mediaType)),
             handler.listSupportedMediaTypes());
     }
 
+    private HandlerV2 handlerFailingWhenParsing(String expectedMessage) {
+        return new HandlerV2() {
+            @Override
+            protected RequestBody parseInput(String inputString) {
+                throw new RuntimeException(expectedMessage);
+            }
+        };
+    }
+
+    private APIGatewayProxyRequestEvent requestWithBodyWithEmptyFields() {
+        RequestBody requestBody = new RequestBody();
+        requestBody.setField1("Some value");
+        requestBody.setField2(null);
+
+        String json = attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(requestBody)).orElseThrow();
+        return new APIGatewayProxyRequestEvent()
+            .withBody(json);
+    }
+
+    private Problem extractProblemFromFailureResponse(APIGatewayProxyResponseEvent responseEvent) {
+        return attempt(() -> JsonUtils.dtoObjectMapper.readValue(responseEvent.getBody(), Problem.class)).orElseThrow();
+    }
+
+    private HandlerV2 handlerThatThrowsUncheckedExceptions() {
+        return new HandlerV2() {
+            @Override
+            protected RequestBody processInput(RequestBody input, APIGatewayProxyRequestEvent requestInfo,
+                                               Context context) {
+                throwUncheckedExceptions();
+                return null;
+            }
+        };
+    }
+
     //
-    //    private <T> GatewayResponse<T> getResponse(Class<T> type, InputStream input, Handler handler) throws
-    //    IOException {
-    //        ByteArrayOutputStream outputStream = outputStream();
-    //        handler.handleRequest(input, outputStream, context);
-    //        return GatewayResponse.fromOutputStream(outputStream);
-    //    }
+    private HandlerV2 handlerThatOverridesListSupportedMediaTypes() {
+        return new HandlerV2() {
+            @Override
+            public List<MediaType> listSupportedMediaTypes() {
+                return List.of(MediaType.JSON_UTF_8, MediaTypes.APPLICATION_JSON_LD);
+            }
+        };
+    }
+
+    private void throwUncheckedExceptions() {
+        try {
+            throw new IllegalStateException(BOTTOM_EXCEPTION_MESSAGE);
+        } catch (IllegalStateException e) {
+            try {
+                throw new IllegalArgumentException(e);
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalCallerException(ex);
+            }
+        }
+    }
+
     //
-    //    private GatewayResponse<String> getStringResponse(InputStream input, Handler handler) throws IOException {
-    //        return getResponse(String.class, input, handler);
-    //    }
-    //
-    //    private GatewayResponse<Problem> getProblemResponse(InputStream input, Handler handler) throws IOException {
-    //        return getResponse(Problem.class, input, handler);
-    //    }
-    //
-    //    private Handler handlerFailingWhenParsing(String expectedMessage) {
-    //        return new Handler() {
-    //            @Override
-    //            protected RequestBody parseInput(String inputString) {
-    //                throw new RuntimeException(expectedMessage);
-    //            }
-    //        };
-    //    }
-    //
-    //    private InputStream requestWithBodyWithEmptyFields() throws JsonProcessingException {
-    //        RequestBody requestBody = new RequestBody();
-    //        requestBody.setField1("Some value");
-    //        requestBody.setField2(null);
-    //
-    //        return new HandlerRequestBuilder<RequestBody>(defaultRestObjectMapper)
-    //            .withBody(requestBody)
-    //            .build();
-    //    }
-    //
-    //    private InputStream requestWithBodyWithoutType() throws JsonProcessingException {
-    //        RequestBody requestBody = new RequestBody();
-    //        requestBody.setField1("Some value");
-    //        requestBody.setField2("Some value");
-    //        ObjectNode objectWithoutType = defaultRestObjectMapper.convertValue(requestBody, ObjectNode.class);
-    //        objectWithoutType.remove(RequestBody.TYPE_ATTRIBUTE);
-    //
-    //        return new HandlerRequestBuilder<ObjectNode>(defaultRestObjectMapper)
-    //            .withBody(objectWithoutType)
-    //            .build();
-    //    }
-    //
-    //    private Problem getProblemFromFailureResponse(ByteArrayOutputStream outputStream) throws
-    //    JsonProcessingException {
-    //        JavaType javaType = defaultRestObjectMapper.getTypeFactory()
-    //            .constructParametricType(GatewayResponse.class, Problem.class);
-    //        GatewayResponse<Problem> response = defaultRestObjectMapper.readValue(outputStream.toString(), javaType);
-    //        return response.getBodyObject(Problem.class);
-    //    }
-    //
-    //    private GatewayResponse<Problem> getApiGatewayResponse(ByteArrayOutputStream outputStream)
-    //        throws JsonProcessingException {
-    //        TypeReference<GatewayResponse<Problem>> tr = new TypeReference<>() {
-    //        };
-    //        return defaultRestObjectMapper.readValue(outputStream.toString(StandardCharsets.UTF_8), tr);
-    //    }
-    //
-    //    private Handler handlerThatThrowsUncheckedExceptions() {
-    //        return new Handler() {
-    //            @Override
-    //            protected RequestBody processInput(RequestBody input, RequestInfo requestInfo, Context context) {
-    //                throwUncheckedExceptions();
-    //                return null;
-    //            }
-    //        };
-    //    }
-    //
-    //    private Handler handlerThatOverridesListSupportedMediaTypes() {
-    //        return new Handler() {
-    //            @Override
-    //            public List<MediaType> listSupportedMediaTypes() {
-    //                return List.of(MediaType.JSON_UTF_8, MediaTypes.APPLICATION_JSON_LD);
-    //            }
-    //        };
-    //    }
-    //
-    //    private Handler handlerThatOverridesGetFailureStatusCode() {
-    //        return new Handler() {
-    //            @Override
-    //            public int getFailureStatusCode(RequestBody input, ApiGatewayException exception) {
-    //                return OVERRIDDEN_STATUS_CODE;
-    //            }
-    //
-    //            @Override
-    //            protected RequestBody processInput(RequestBody input, RequestInfo requestInfo, Context context)
-    //                throws ApiGatewayException {
-    //                throwExceptions();
-    //                return null;
-    //            }
-    //        };
-    //    }
-    //
-    //    private void throwUncheckedExceptions() {
-    //        try {
-    //            throw new IllegalStateException(BOTTOM_EXCEPTION_MESSAGE);
-    //        } catch (IllegalStateException e) {
-    //            try {
-    //                throw new IllegalArgumentException(e);
-    //            } catch (IllegalArgumentException ex) {
-    //                throw new IllegalCallerException(ex);
-    //            }
-    //        }
-    //    }
-    //
-    //    private void throwExceptions() throws ApiGatewayException {
-    //        try {
-    //            throw new URISyntaxException("", BOTTOM_EXCEPTION_MESSAGE);
-    //        } catch (URISyntaxException e) {
-    //            try {
-    //                throw new XMLParseException(e, MIDDLE_EXCEPTION_MESSAGE);
-    //            } catch (XMLParseException ex) {
-    //                throw new TestException(ex, TOP_EXCEPTION_MESSAGE);
-    //            }
-    //        }
-    //    }
-    //
-    //    private InputStream anyRequest() throws JsonProcessingException {
-    //        return requestWithHeaders();
-    //    }
-    //
-    //    private InputStream requestWithHeadersAndPath() throws JsonProcessingException {
-    //        ObjectNode request = defaultRestObjectMapper.createObjectNode();
-    //        ObjectNode node = createBody();
-    //        request.set("body", node);
-    //        request.set("headers", createHeaders());
-    //        request.put("path", PATH);
-    //        return jsonNodeToInputStream(request);
-    //    }
-    //
-    //    private InputStream jsonNodeToInputStream(JsonNode request) throws JsonProcessingException {
-    //        String requestString = defaultRestObjectMapper.writeValueAsString(request);
-    //        return IoUtils.stringToStream(requestString);
-    //    }
-    //
-    private APIGatewayProxyRequestEvent requestWithAcceptHeader(String acceptHeader)  {
+    private void throwExceptions() throws ApiGatewayException {
+        try {
+            throw new URISyntaxException("", BOTTOM_EXCEPTION_MESSAGE);
+        } catch (URISyntaxException e) {
+            try {
+                throw new XMLParseException(e, MIDDLE_EXCEPTION_MESSAGE);
+            } catch (XMLParseException ex) {
+                throw new TestException(ex, TOP_EXCEPTION_MESSAGE);
+            }
+        }
+    }
+
+    private APIGatewayProxyRequestEvent requestWithHeadersAndPath() {
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
+        request.setBody(createBody());
+        request.setHeaders(createHeaders());
+        request.setPath(PATH);
+        return request;
+    }
+
+    private APIGatewayProxyRequestEvent requestWithAcceptHeader(String acceptHeader) {
         Map<String, String> headers = new ConcurrentHashMap<>();
         headers.put(HttpHeaders.ACCEPT, acceptHeader);
         return requestWithHeaders(headers);
     }
 
-    //
-    private APIGatewayProxyRequestEvent requestWithHeaders(Map<String, String> headers)   {
+    private APIGatewayProxyRequestEvent requestWithHeaders(Map<String, String> headers) {
         return new APIGatewayProxyRequestEvent()
             .withBody(randomRequestBody())
             .withHeaders(headers)
             .withPathParameters(Collections.emptyMap());
     }
 
+    private APIGatewayProxyRequestEvent requestWithHeaders() {
+        Map<String, String> randomHeaders = Map.of(randomString(), randomString(), randomString(), randomString());
+        return new APIGatewayProxyRequestEvent().withBody(createBody())
+            .withHeaders(randomHeaders);
+    }
+
     private String randomRequestBody() {
-        RequestBody requestBody= new RequestBody();
+        RequestBody requestBody = new RequestBody();
         requestBody.setField1(randomString());
         requestBody.setField2(randomString());
         return requestBody.toString();
     }
 
-    //
-    private APIGatewayProxyRequestEvent requestWithHeaders() {
-        Map<String, String> randomHeaders = Map.of(randomString(), randomString(), randomString(), randomString());
-        return new APIGatewayProxyRequestEvent().withBody(randomJson())
-            .withHeaders(randomHeaders);
+    private Map<String, String> createHeaders() {
+        Map<String, String> headers = new ConcurrentHashMap<>();
+        headers.put(HttpHeaders.ACCEPT, MediaType.JSON_UTF_8.toString());
+        headers.put(CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
+        return headers;
     }
-    //
-    //    private JsonNode createHeaders() {
-    //        Map<String, String> headers = new ConcurrentHashMap<>();
-    //        headers.put(HttpHeaders.ACCEPT, MediaType.JSON_UTF_8.toString());
-    //        headers.put(CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
-    //        return createHeaders(headers);
-    //    }
-    //
 
-    //
-    //    private ObjectNode createBody() {
-    //        RequestBody requestBody = new RequestBody();
-    //        requestBody.setField1("value1");
-    //        requestBody.setField2("value2");
-    //        return defaultRestObjectMapper.convertValue(requestBody, ObjectNode.class);
-    //    }
-    //
-    //    private ByteArrayOutputStream outputStream() {
-    //        return new ByteArrayOutputStream();
-    //    }
-    //
-    //    private Handler handlerThatThrowsExceptions() {
-    //        return new Handler() {
-    //            @Override
-    //            protected RequestBody processInput(RequestBody input, RequestInfo requestInfo, Context context)
-    //                throws ApiGatewayException {
-    //                throwExceptions();
-    //                return null;
-    //            }
-    //        };
-    //    }
+    private String createBody() {
+        RequestBody requestBody = new RequestBody();
+        requestBody.setField1("value1");
+        requestBody.setField2("value2");
+        return attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(requestBody)).orElseThrow();
+    }
+
+    private HandlerV2 handlerThatThrowsExceptions() {
+        return new HandlerV2() {
+            @Override
+            protected RequestBody processInput(RequestBody input, APIGatewayProxyRequestEvent requestInfo,
+                                               Context context)
+                throws ApiGatewayException {
+                throwExceptions();
+                return null;
+            }
+        };
+    }
 }

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerV2Test.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerV2Test.java
@@ -1,0 +1,537 @@
+package nva.commons.apigateway;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomJson;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.net.HttpHeaders;
+import com.google.common.net.MediaType;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import nva.commons.apigateway.exceptions.UnsupportedAcceptHeaderException;
+import nva.commons.apigateway.testutils.HandlerV2;
+import nva.commons.apigateway.testutils.RequestBody;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ApiGatewayHandlerV2Test {
+
+    public static final String TOP_EXCEPTION_MESSAGE = "TOP Exception";
+    public static final String MIDDLE_EXCEPTION_MESSAGE = "MIDDLE Exception";
+    public static final String BOTTOM_EXCEPTION_MESSAGE = "BOTTOM Exception";
+    public static final String SOME_REQUEST_ID = "RequestID:123456";
+    public static final int OVERRIDDEN_STATUS_CODE = 418;  //I'm a teapot
+    public static final Path EVENT_WITH_UNKNOWN_REQUEST_INFO = Path.of("apiGatewayMessages",
+                                                                       "eventWithUnknownRequestInfo.json");
+    private static final String PATH = "path1/path2/path3";
+    private Context context;
+    private HandlerV2 handler;
+
+    /**
+     * Setup.
+     */
+    @BeforeEach
+    public void setup() {
+        context = mock(Context.class);
+        when(context.getAwsRequestId()).thenReturn(SOME_REQUEST_ID);
+        handler = new HandlerV2();
+    }
+
+    @Test
+    @DisplayName("ApiGatewayHandler has a constructor with input class as only parameter")
+    void apiGatewayHandlerHasAConstructorWithInputClassAsOnlyParameter() {
+        ApiGatewayHandlerV2<String, String> handler = new ApiGatewayHandlerV2<>(String.class) {
+            @Override
+            protected String processInput(String input, APIGatewayProxyRequestEvent requestInfo, Context context) {
+                return null;
+            }
+
+            @Override
+            protected Integer getSuccessStatusCode(String input, String output) {
+                return HttpURLConnection.HTTP_OK;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("handleRequest should have available the request headers")
+    void handleRequestShouldHaveAvailableTheRequestHeaders() throws IOException {
+        var input = requestWithHeaders();
+        handler.handleRequest(input, context);
+        Map<String, String> headers = handler.getHeaders();
+        var expectedHeaders = input.getHeaders();
+        expectedHeaders.keySet()
+            .forEach(expectedHeader ->
+                         assertThat(headers.get(expectedHeader), is(equalTo(expectedHeaders.get(expectedHeader)))));
+    }
+
+    @ParameterizedTest(name = "handleRequest should return Unsupported media-type when input is {0}")
+    @ValueSource(strings = {
+        "application/xml",
+        "text/plain; charset=UTF-8"
+    })
+    void handleRequestShouldReturnUnsupportedMediaTypeOnUnsupportedAcceptHeader(String mediaType)
+        throws IOException {
+        APIGatewayProxyRequestEvent input = requestWithAcceptHeader(mediaType);
+
+        var response = handler.handleRequest(input, context);
+
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNSUPPORTED_TYPE)));
+        String expectedMessage = getUnsupportedMediaTypeErrorMessage(mediaType);
+        assertThat(response.getBody(), containsString(expectedMessage));
+    }
+
+    //
+    //    @ParameterizedTest(name = "handleRequest should return OK when input is {0}")
+    //    @ValueSource(strings = {
+    //        "*/*",
+    //        "application/json",
+    //        "application/json; charset=UTF-8",
+    //        "text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8"
+    //    })
+    //    public void handleRequestShouldReturnOkOnSupportedAcceptHeader(String mediaType) throws IOException {
+    //        InputStream input = requestWithAcceptHeader(mediaType);
+    //
+    //        GatewayResponse<String> response = getStringResponse(input, handler);
+    //
+    //        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+    //    }
+    //
+    //    @Test
+    //    public void handleRequestReturnsContentTypeJsonOnAcceptWildcard()
+    //        throws IOException {
+    //        Handler handler = handlerThatOverridesListSupportedMediaTypes();
+    //
+    //        InputStream input = requestWithAcceptHeader(MediaType.ANY_TYPE.toString());
+    //
+    //        GatewayResponse<String> response = getStringResponse(input, handler);
+    //
+    //        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+    //        assertThat(response.getHeaders().get(CONTENT_TYPE), is(equalTo(MediaType.JSON_UTF_8.toString())));
+    //    }
+    //
+    //    @Test
+    //    public void handleRequestReturnsContentTypeJsonLdOnAcceptJsonLd()
+    //        throws IOException {
+    //        Handler handler = handlerThatOverridesListSupportedMediaTypes();
+    //
+    //        InputStream input = requestWithAcceptHeader(MediaTypes.APPLICATION_JSON_LD.toString());
+    //
+    //        GatewayResponse<String> response = getStringResponse(input, handler);
+    //
+    //        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+    //        assertThat(response.getHeaders().get(CONTENT_TYPE), is(equalTo(MediaTypes.APPLICATION_JSON_LD.toString
+    //        ())));
+    //    }
+    //
+    //    @Test
+    //    @DisplayName("handleRequest should have available the request path")
+    //    public void handleRequestShouldHaveAvailableTheRequestPath() throws IOException {
+    //        InputStream input = requestWithHeadersAndPath();
+    //
+    //        getStringResponse(input, handler);
+    //
+    //        String actualPath = handler.getPath();
+    //        JsonNode expectedHeaders = createHeaders();
+    //        expectedHeaders.fieldNames().forEachRemaining(expectedHeader -> assertThat(actualPath, is(equalTo(PATH)
+    //        )));
+    //    }
+    //
+    //    @Test
+    //    @DisplayName("handleRequest allows response headers depended on input")
+    //    public void apiGatewayHandlerAllowsResponseHeadersDependedOnInput() throws IOException {
+    //        InputStream input = requestWithHeadersAndPath();
+    //        GatewayResponse<String> response = getStringResponse(input, handler);
+    //        assertTrue(response.getHeaders().containsKey(HttpHeaders.WARNING));
+    //    }
+    //
+    //    @Test
+    //    public void handleRequestDoesNotThrowExceptionOnUnknownFieldsInRequestInfo() throws IOException {
+    //        InputStream input = IoUtils.inputStreamFromResources(EVENT_WITH_UNKNOWN_REQUEST_INFO);
+    //
+    //        GatewayResponse<RequestBody> response = getResponse(RequestBody.class, input, handler);
+    //        RequestBody body = response.getBodyObject(RequestBody.class);
+    //
+    //        String expectedValueForField1 = "value1";
+    //        String expectedValueForField2 = "value2";
+    //        assertThat(body.getField1(), containsString(expectedValueForField1));
+    //        assertThat(body.getField2(), containsString(expectedValueForField2));
+    //    }
+    //
+    //    @Test
+    //    @DisplayName("Logger logs the whole exception stacktrace when an exception has occurred 2")
+    //    public void loggerLogsTheWholeExceptionStackTraceWhenAnExceptionHasOccurred() throws IOException {
+    //        TestAppender appender = LogUtils.getTestingAppenderForRootLogger();
+    //        Handler handler = handlerThatThrowsExceptions();
+    //        handler.handleRequest(requestWithHeadersAndPath(), outputStream(), context);
+    //
+    //        String logs = appender.getMessages();
+    //
+    //        assertThat(logs, containsString(URISyntaxException.class.getName()));
+    //        assertThat(logs, containsString(XMLParseException.class.getName()));
+    //        assertThat(logs, containsString(TestException.class.getName()));
+    //        assertThat(logs, containsString(BOTTOM_EXCEPTION_MESSAGE));
+    //        assertThat(logs, containsString(MIDDLE_EXCEPTION_MESSAGE));
+    //        assertThat(logs, containsString(TOP_EXCEPTION_MESSAGE));
+    //    }
+    //
+    //    @Test
+    //    @DisplayName("Logger logs the whole exception stacktrace when an exception has occurred")
+    //    public void loggerLogsTheWholeExceptionStackTraceWhenAnUncheckedExceptionHasOccurred() throws IOException {
+    //        TestAppender appender = LogUtils.getTestingAppenderForRootLogger();
+    //        Handler handler = handlerThatThrowsUncheckedExceptions();
+    //
+    //        handler.handleRequest(requestWithHeadersAndPath(), outputStream(), context);
+    //
+    //        String logs = appender.getMessages();
+    //
+    //        assertThat(logs, containsString(IllegalStateException.class.getName()));
+    //        assertThat(logs, containsString(IllegalArgumentException.class.getName()));
+    //        assertThat(logs, containsString(IllegalCallerException.class.getName()));
+    //        assertThat(logs, containsString(BOTTOM_EXCEPTION_MESSAGE));
+    //    }
+    //
+    //    @Test
+    //    @DisplayName("Handler does not reveal information for runtime exceptions")
+    //    public void handlerDoesNotRevealInformationForRuntimeExceptions() throws IOException {
+    //        Handler handler = handlerThatThrowsUncheckedExceptions();
+    //        ByteArrayOutputStream outputStream = outputStream();
+    //        handler.handleRequest(requestWithHeaders(), outputStream, context);
+    //        Problem problem = getProblemFromFailureResponse(outputStream);
+    //        String details = problem.getDetail();
+    //        assertThat(details, not(containsString(BOTTOM_EXCEPTION_MESSAGE)));
+    //        assertThat(details, not(containsString(MIDDLE_EXCEPTION_MESSAGE)));
+    //        assertThat(details, not(containsString(TOP_EXCEPTION_MESSAGE)));
+    //        assertThat(details, containsString(
+    //            ApiGatewayHandler.MESSAGE_FOR_RUNTIME_EXCEPTIONS_HIDING_IMPLEMENTATION_DETAILS_TO_API_CLIENTS));
+    //    }
+    //
+    //    @Test
+    //    @DisplayName("Failure message contains exception message and status code when an Exception is thrown")
+    //    public void failureMessageContainsExceptionMessageAndStatusCodeWhenAnExceptionIsThrown()
+    //        throws IOException {
+    //        Handler handler = handlerThatThrowsExceptions();
+    //
+    //        GatewayResponse<Problem> responseParsing = getProblemResponse(requestWithHeadersAndPath(), handler);
+    //
+    //        Problem problem = responseParsing.getBodyObject(Problem.class);
+    //        assertThat(problem.getDetail(), containsString(TOP_EXCEPTION_MESSAGE));
+    //        assertThat(problem.getTitle(), containsString(Status.NOT_FOUND.getReasonPhrase()));
+    //
+    //        assertThat(problem.getParameters().get(REQUEST_ID), is(equalTo(SOME_REQUEST_ID)));
+    //        assertThat(problem.getStatus(), is(Status.NOT_FOUND));
+    //    }
+    //
+    //    @Test
+    //    @DisplayName("Failure message contains application/problem+json ContentType when an Exception is thrown")
+    //    public void failureMessageContainsApplicationProblemJsonContentTypeWhenExceptionIsThrown()
+    //        throws IOException {
+    //        Handler handler = handlerThatThrowsExceptions();
+    //
+    //        GatewayResponse<Problem> responseParsing = getProblemResponse(requestWithHeadersAndPath(), handler);
+    //
+    //        assertThat(responseParsing.getHeaders().get(CONTENT_TYPE), is(equalTo(APPLICATION_PROBLEM_JSON.toString
+    //        ())));
+    //    }
+    //
+    //    @Test
+    //    @DisplayName("getFailureStatusCode sets the status code to the ApiGatewayResponse")
+    //    public void getFailureStatusCodeSetsTheStatusCodeToTheApiGatewayResponse() throws IOException {
+    //        Handler handler = handlerThatOverridesGetFailureStatusCode();
+    //
+    //        GatewayResponse<Problem> response = getProblemResponse(anyRequest(), handler);
+    //
+    //        assertThat(response.getStatusCode(), is(equalTo(OVERRIDDEN_STATUS_CODE)));
+    //        assertThat(response.getBodyObject(Problem.class).getStatus().getStatusCode(),
+    //                   is(equalTo(OVERRIDDEN_STATUS_CODE)));
+    //    }
+    //
+    //    @Test
+    //    @DisplayName("getFailureStatusCode returns by default the status code of the ApiGatewayException")
+    //    public void getFailureStatusCodeReturnsByDefaultTheStatusCodeOfTheApiGatewayException() throws IOException {
+    //        Handler handler = handlerThatThrowsExceptions();
+    //
+    //        GatewayResponse<Problem> response = getProblemResponse(anyRequest(), handler);
+    //
+    //        assertThat(response.getStatusCode(), is(equalTo(TestException.ERROR_STATUS_CODE)));
+    //        assertThat(response.getBodyObject(Problem.class).getStatus().getStatusCode(),
+    //                   is(equalTo(TestException.ERROR_STATUS_CODE)));
+    //    }
+    //
+    //    @Test
+    //    public void handlerLogsRequestIdForEveryRequest() throws IOException {
+    //        var appender = LogUtils.getTestingAppender(RestRequestHandler.class);
+    //        var output = outputStream();
+    //        var contextWithRequestId = new FakeContext();
+    //        var expectedRequestId = contextWithRequestId.getAwsRequestId();
+    //        handler.handleRequest(requestWithHeadersAndPath(), output, contextWithRequestId);
+    //        assertThat(appender.getMessages(), containsString(expectedRequestId));
+    //    }
+    //
+    //    @Test
+    //    public void itReturnsResponseWithPopulatedFieldsAndBothEmptyAndNonEmptyLists() throws IOException {
+    //        var output = outputStream();
+    //        InputStream input = requestWithBodyWithEmptyFields();
+    //        handler.handleRequest(input, output, context);
+    //        GatewayResponse<JsonNode> response = GatewayResponse.fromOutputStream(output);
+    //        JsonNode jsonNode = response.getBodyObject(JsonNode.class);
+    //        String nullField = RequestBody.FIELD2;
+    //        String presentField = RequestBody.FIELD1;
+    //        assertThat(jsonNode.has(presentField), is(true));
+    //        assertThat(jsonNode.has(nullField), is(false));
+    //        assertThat(jsonNode.has(RequestBody.EMPTY_LIST), is(true));
+    //        assertThat(jsonNode.get(RequestBody.EMPTY_LIST), is(instanceOf(ArrayNode.class)));
+    //    }
+    //
+    //    @Test
+    //    public void handlerReturnsBadRequestWhenInputParsingFails() throws IOException {
+    //        String expectedMessage = "Expected error message when parsing fails";
+    //        Handler handler = handlerFailingWhenParsing(expectedMessage);
+    //        InputStream input = requestWithHeadersAndPath();
+    //        GatewayResponse<Problem> response = getProblemResponse(input, handler);
+    //        Problem problem = response.getBodyObject(Problem.class);
+    //
+    //        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
+    //        assertThat(problem.getDetail(), containsString(expectedMessage));
+    //    }
+    //
+    //    @Test
+    //    void handlerSerializesBodyWithNonDefaultSerializationWhenDefaultSerializerIsOverridden() throws IOException {
+    //        ObjectMapper spiedMapper = spy(defaultRestObjectMapper);
+    //        var handler = new Handler(spiedMapper);
+    //        var inputStream = requestWithHeaders();
+    //        var outputStream = outputStream();
+    //        handler.handleRequest(inputStream, outputStream, context);
+    //        verify(spiedMapper, atLeast(1)).writeValueAsString(any());
+    //    }
+    //
+    //    @Test
+    //    void handlerSendsRedirectionWhenItReceivesARedirectException() throws IOException {
+    //        var expectedRedirectLocation = randomUri();
+    //        var expectedRedirectStatusCode = HttpURLConnection.HTTP_SEE_OTHER;
+    //        var handler = new RedirectHandler(expectedRedirectLocation, expectedRedirectStatusCode);
+    //        var request = requestWithHeaders(Map.of(HttpHeaders.ACCEPT, MediaType.HTML_UTF_8.toString()));
+    //        var response = getResponse(Void.class, request, handler);
+    //        assertThat(response.getStatusCode(), is(equalTo(expectedRedirectStatusCode)));
+    //        assertThat(response.getHeaders(), hasEntry(HttpHeaders.LOCATION, expectedRedirectLocation.toString()));
+    //    }
+    //
+    private String getUnsupportedMediaTypeErrorMessage(String mediaType) {
+        return UnsupportedAcceptHeaderException.createMessage(
+            List.of(MediaType.parse(mediaType)),
+            handler.listSupportedMediaTypes());
+    }
+
+    //
+    //    private <T> GatewayResponse<T> getResponse(Class<T> type, InputStream input, Handler handler) throws
+    //    IOException {
+    //        ByteArrayOutputStream outputStream = outputStream();
+    //        handler.handleRequest(input, outputStream, context);
+    //        return GatewayResponse.fromOutputStream(outputStream);
+    //    }
+    //
+    //    private GatewayResponse<String> getStringResponse(InputStream input, Handler handler) throws IOException {
+    //        return getResponse(String.class, input, handler);
+    //    }
+    //
+    //    private GatewayResponse<Problem> getProblemResponse(InputStream input, Handler handler) throws IOException {
+    //        return getResponse(Problem.class, input, handler);
+    //    }
+    //
+    //    private Handler handlerFailingWhenParsing(String expectedMessage) {
+    //        return new Handler() {
+    //            @Override
+    //            protected RequestBody parseInput(String inputString) {
+    //                throw new RuntimeException(expectedMessage);
+    //            }
+    //        };
+    //    }
+    //
+    //    private InputStream requestWithBodyWithEmptyFields() throws JsonProcessingException {
+    //        RequestBody requestBody = new RequestBody();
+    //        requestBody.setField1("Some value");
+    //        requestBody.setField2(null);
+    //
+    //        return new HandlerRequestBuilder<RequestBody>(defaultRestObjectMapper)
+    //            .withBody(requestBody)
+    //            .build();
+    //    }
+    //
+    //    private InputStream requestWithBodyWithoutType() throws JsonProcessingException {
+    //        RequestBody requestBody = new RequestBody();
+    //        requestBody.setField1("Some value");
+    //        requestBody.setField2("Some value");
+    //        ObjectNode objectWithoutType = defaultRestObjectMapper.convertValue(requestBody, ObjectNode.class);
+    //        objectWithoutType.remove(RequestBody.TYPE_ATTRIBUTE);
+    //
+    //        return new HandlerRequestBuilder<ObjectNode>(defaultRestObjectMapper)
+    //            .withBody(objectWithoutType)
+    //            .build();
+    //    }
+    //
+    //    private Problem getProblemFromFailureResponse(ByteArrayOutputStream outputStream) throws
+    //    JsonProcessingException {
+    //        JavaType javaType = defaultRestObjectMapper.getTypeFactory()
+    //            .constructParametricType(GatewayResponse.class, Problem.class);
+    //        GatewayResponse<Problem> response = defaultRestObjectMapper.readValue(outputStream.toString(), javaType);
+    //        return response.getBodyObject(Problem.class);
+    //    }
+    //
+    //    private GatewayResponse<Problem> getApiGatewayResponse(ByteArrayOutputStream outputStream)
+    //        throws JsonProcessingException {
+    //        TypeReference<GatewayResponse<Problem>> tr = new TypeReference<>() {
+    //        };
+    //        return defaultRestObjectMapper.readValue(outputStream.toString(StandardCharsets.UTF_8), tr);
+    //    }
+    //
+    //    private Handler handlerThatThrowsUncheckedExceptions() {
+    //        return new Handler() {
+    //            @Override
+    //            protected RequestBody processInput(RequestBody input, RequestInfo requestInfo, Context context) {
+    //                throwUncheckedExceptions();
+    //                return null;
+    //            }
+    //        };
+    //    }
+    //
+    //    private Handler handlerThatOverridesListSupportedMediaTypes() {
+    //        return new Handler() {
+    //            @Override
+    //            public List<MediaType> listSupportedMediaTypes() {
+    //                return List.of(MediaType.JSON_UTF_8, MediaTypes.APPLICATION_JSON_LD);
+    //            }
+    //        };
+    //    }
+    //
+    //    private Handler handlerThatOverridesGetFailureStatusCode() {
+    //        return new Handler() {
+    //            @Override
+    //            public int getFailureStatusCode(RequestBody input, ApiGatewayException exception) {
+    //                return OVERRIDDEN_STATUS_CODE;
+    //            }
+    //
+    //            @Override
+    //            protected RequestBody processInput(RequestBody input, RequestInfo requestInfo, Context context)
+    //                throws ApiGatewayException {
+    //                throwExceptions();
+    //                return null;
+    //            }
+    //        };
+    //    }
+    //
+    //    private void throwUncheckedExceptions() {
+    //        try {
+    //            throw new IllegalStateException(BOTTOM_EXCEPTION_MESSAGE);
+    //        } catch (IllegalStateException e) {
+    //            try {
+    //                throw new IllegalArgumentException(e);
+    //            } catch (IllegalArgumentException ex) {
+    //                throw new IllegalCallerException(ex);
+    //            }
+    //        }
+    //    }
+    //
+    //    private void throwExceptions() throws ApiGatewayException {
+    //        try {
+    //            throw new URISyntaxException("", BOTTOM_EXCEPTION_MESSAGE);
+    //        } catch (URISyntaxException e) {
+    //            try {
+    //                throw new XMLParseException(e, MIDDLE_EXCEPTION_MESSAGE);
+    //            } catch (XMLParseException ex) {
+    //                throw new TestException(ex, TOP_EXCEPTION_MESSAGE);
+    //            }
+    //        }
+    //    }
+    //
+    //    private InputStream anyRequest() throws JsonProcessingException {
+    //        return requestWithHeaders();
+    //    }
+    //
+    //    private InputStream requestWithHeadersAndPath() throws JsonProcessingException {
+    //        ObjectNode request = defaultRestObjectMapper.createObjectNode();
+    //        ObjectNode node = createBody();
+    //        request.set("body", node);
+    //        request.set("headers", createHeaders());
+    //        request.put("path", PATH);
+    //        return jsonNodeToInputStream(request);
+    //    }
+    //
+    //    private InputStream jsonNodeToInputStream(JsonNode request) throws JsonProcessingException {
+    //        String requestString = defaultRestObjectMapper.writeValueAsString(request);
+    //        return IoUtils.stringToStream(requestString);
+    //    }
+    //
+    private APIGatewayProxyRequestEvent requestWithAcceptHeader(String acceptHeader)  {
+        Map<String, String> headers = new ConcurrentHashMap<>();
+        headers.put(HttpHeaders.ACCEPT, acceptHeader);
+        return requestWithHeaders(headers);
+    }
+
+    //
+    private APIGatewayProxyRequestEvent requestWithHeaders(Map<String, String> headers)   {
+        return new APIGatewayProxyRequestEvent()
+            .withBody(randomRequestBody())
+            .withHeaders(headers)
+            .withPathParameters(Collections.emptyMap());
+    }
+
+    private String randomRequestBody() {
+        RequestBody requestBody= new RequestBody();
+        requestBody.setField1(randomString());
+        requestBody.setField2(randomString());
+        return requestBody.toString();
+    }
+
+    //
+    private APIGatewayProxyRequestEvent requestWithHeaders() {
+        Map<String, String> randomHeaders = Map.of(randomString(), randomString(), randomString(), randomString());
+        return new APIGatewayProxyRequestEvent().withBody(randomJson())
+            .withHeaders(randomHeaders);
+    }
+    //
+    //    private JsonNode createHeaders() {
+    //        Map<String, String> headers = new ConcurrentHashMap<>();
+    //        headers.put(HttpHeaders.ACCEPT, MediaType.JSON_UTF_8.toString());
+    //        headers.put(CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
+    //        return createHeaders(headers);
+    //    }
+    //
+
+    //
+    //    private ObjectNode createBody() {
+    //        RequestBody requestBody = new RequestBody();
+    //        requestBody.setField1("value1");
+    //        requestBody.setField2("value2");
+    //        return defaultRestObjectMapper.convertValue(requestBody, ObjectNode.class);
+    //    }
+    //
+    //    private ByteArrayOutputStream outputStream() {
+    //        return new ByteArrayOutputStream();
+    //    }
+    //
+    //    private Handler handlerThatThrowsExceptions() {
+    //        return new Handler() {
+    //            @Override
+    //            protected RequestBody processInput(RequestBody input, RequestInfo requestInfo, Context context)
+    //                throws ApiGatewayException {
+    //                throwExceptions();
+    //                return null;
+    //            }
+    //        };
+    //    }
+}

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/HandlerV2.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/HandlerV2.java
@@ -3,16 +3,13 @@ package nva.commons.apigateway.testutils;
 import static nva.commons.apigateway.RequestInfo.PROXY_TAG;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.net.HttpHeaders;
 import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.Map;
-import nva.commons.apigateway.ApiGatewayHandler;
+import java.util.Optional;
 import nva.commons.apigateway.ApiGatewayHandlerV2;
-import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
-import nva.commons.core.Environment;
 
 public class HandlerV2 extends ApiGatewayHandlerV2<RequestBody, RequestBody> {
 
@@ -25,12 +22,14 @@ public class HandlerV2 extends ApiGatewayHandlerV2<RequestBody, RequestBody> {
         super(RequestBody.class);
     }
 
-
     @Override
     protected RequestBody processInput(RequestBody input, APIGatewayProxyRequestEvent requestInfo, Context context)
         throws ApiGatewayException {
         this.headers = requestInfo.getHeaders();
-        this.proxy = requestInfo.getPathParameters().get(PROXY_TAG);
+        this.proxy = Optional.ofNullable(requestInfo)
+            .map(APIGatewayProxyRequestEvent::getPathParameters)
+            .map(pathParameters -> pathParameters.get(PROXY_TAG))
+            .orElse(null);
         this.path = requestInfo.getPath();
         this.body = input;
         this.addAdditionalSuccessHeaders(this::additionalHeaders);

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/HandlerV2.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/HandlerV2.java
@@ -1,0 +1,64 @@
+package nva.commons.apigateway.testutils;
+
+import static nva.commons.apigateway.RequestInfo.PROXY_TAG;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.HttpHeaders;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.Map;
+import nva.commons.apigateway.ApiGatewayHandler;
+import nva.commons.apigateway.ApiGatewayHandlerV2;
+import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.core.Environment;
+
+public class HandlerV2 extends ApiGatewayHandlerV2<RequestBody, RequestBody> {
+
+    private Map<String, String> headers;
+    private String proxy;
+    private String path;
+    private RequestBody body;
+
+    public HandlerV2() {
+        super(RequestBody.class);
+    }
+
+
+    @Override
+    protected RequestBody processInput(RequestBody input, APIGatewayProxyRequestEvent requestInfo, Context context)
+        throws ApiGatewayException {
+        this.headers = requestInfo.getHeaders();
+        this.proxy = requestInfo.getPathParameters().get(PROXY_TAG);
+        this.path = requestInfo.getPath();
+        this.body = input;
+        this.addAdditionalSuccessHeaders(this::additionalHeaders);
+        return this.body;
+    }
+
+    private Map<String, String> additionalHeaders() {
+        return Collections.singletonMap(HttpHeaders.WARNING, body.getField1());
+    }
+
+    @Override
+    protected Integer getSuccessStatusCode(RequestBody input, RequestBody output) {
+        return HttpURLConnection.HTTP_OK;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public String getProxy() {
+        return proxy;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public RequestBody getBody() {
+        return body;
+    }
+}

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/RedirectHandlerV2.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/RedirectHandlerV2.java
@@ -1,0 +1,58 @@
+package nva.commons.apigateway.testutils;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.google.common.net.HttpHeaders;
+import com.google.common.net.MediaType;
+import java.net.URI;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.apigateway.exceptions.RedirectException;
+
+public class RedirectHandlerV2 extends HandlerV2 {
+
+    private final URI location;
+    private final Integer redirectStatusCode;
+
+    public RedirectHandlerV2(URI location, Integer redirectStatusCode) {
+        super();
+        this.location = location;
+        this.redirectStatusCode = redirectStatusCode;
+    }
+
+    @Override
+    protected RequestBody processInput(RequestBody input, APIGatewayProxyRequestEvent requestInfo, Context context)
+        throws ApiGatewayException {
+        if (clientIsRequestingHtmlContent(requestInfo)) {
+            throw new ExampleRedirectException(redirectStatusCode, location);
+        }
+        return input;
+    }
+
+    private boolean clientIsRequestingHtmlContent(APIGatewayProxyRequestEvent requestInfo) {
+        var acceptHeader = requestInfo.getHeaders().get(HttpHeaders.ACCEPT);
+        MediaType requestedContent = MediaType.parse(acceptHeader).withoutParameters();
+        return MediaType.HTML_UTF_8.withoutParameters().equals(requestedContent);
+    }
+
+    private static final class ExampleRedirectException extends RedirectException {
+
+        private final URI location;
+        private final Integer statusCode;
+
+        public ExampleRedirectException(Integer statusCode, URI location) {
+            super("Redirection");
+            this.location = location;
+            this.statusCode = statusCode;
+        }
+
+        @Override
+        public URI getLocation() {
+            return location;
+        }
+
+        @Override
+        protected Integer statusCode() {
+            return statusCode;
+        }
+    }
+}

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/RequestBody.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/RequestBody.java
@@ -1,10 +1,12 @@
 package nva.commons.apigateway.testutils;
 
+import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import no.unit.nva.commons.json.JsonUtils;
 
 @JsonTypeInfo(use = Id.NAME, property = RequestBody.TYPE_ATTRIBUTE)
 public class RequestBody {
@@ -66,5 +68,11 @@ public class RequestBody {
         RequestBody that = (RequestBody) o;
         return Objects.equals(field1, that.field1)
                && Objects.equals(field2, that.field2);
+    }
+
+
+    @Override
+    public String toString(){
+        return attempt(()->JsonUtils.dtoObjectMapper.writeValueAsString(this)).orElseThrow();
     }
 }

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/RequestBody.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/RequestBody.java
@@ -70,9 +70,8 @@ public class RequestBody {
                && Objects.equals(field2, that.field2);
     }
 
-
     @Override
-    public String toString(){
-        return attempt(()->JsonUtils.dtoObjectMapper.writeValueAsString(this)).orElseThrow();
+    public String toString() {
+        return attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(this)).orElseThrow();
     }
 }

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.20.12-beta'
+version = '1.20.12-beta2'
 
 repositories {
     mavenCentral()

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.20.11'
+version = '1.20.12-beta'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
A simpler and hopefully slightly faster ApiGatewayHandler that satisfies (almost) all requirements of ApiGatewayHandler as they are expressed by the tests. The only requirements that are not satisfied are the ones that have to do with deserialization of the request body. This is because the responsibility of this will be moved to the implementing methods. 

This is not an effort to substitute Micronaut. This is an effort to check whether we can make some handlers faster until we migrate to Micronaut without changing the code of the services too much.

The major changes are the following:
1. We do not parse the ApiGatewayRequestEvents. Amazon does this for us.
2. This ApiGatewayHandlerV2 is intended to be independent of serialization libraries or in worst case to use something very light. This will come in next PR after we have established the the handler works.
 
