### PR TITLE
AuthorizedBackendClient accepts CognitoCredentials object

### DIFF
--- a/auth/src/main/java/no/unit/nva/auth/AuthorizedBackendClient.java
+++ b/auth/src/main/java/no/unit/nva/auth/AuthorizedBackendClient.java
@@ -39,11 +39,11 @@ public class AuthorizedBackendClient {
     }
 
     @JacocoGenerated
-    public static AuthorizedBackendClient prepareWithBackendCredentials(CognitoCredentials cognitoCredentials) {
-        return prepareWithBackendCredentials(HttpClient.newHttpClient(), cognitoCredentials);
+    public static AuthorizedBackendClient prepareWithCognitoCredentials(CognitoCredentials cognitoCredentials) {
+        return prepareWithCognitoCredentials(HttpClient.newHttpClient(), cognitoCredentials);
     }
 
-    public static AuthorizedBackendClient prepareWithBackendCredentials(HttpClient httpClient,
+    public static AuthorizedBackendClient prepareWithCognitoCredentials(HttpClient httpClient,
                                                                         CognitoCredentials cognitoApiClientCredentials) {
         var client = new AuthorizedBackendClient(httpClient, null, cognitoApiClientCredentials);
         client.refreshToken();
@@ -51,11 +51,11 @@ public class AuthorizedBackendClient {
     }
 
     @JacocoGenerated
-    public static AuthorizedBackendClient prepareWithUserCredentials(String bearerToken) {
-        return prepareWithUserCredentials(HttpClient.newHttpClient(), bearerToken);
+    public static AuthorizedBackendClient prepareWithBearerToken(String bearerToken) {
+        return prepareWithBearerToken(HttpClient.newHttpClient(), bearerToken);
     }
 
-    public static AuthorizedBackendClient prepareWithUserCredentials(HttpClient httpClient, String bearerToken) {
+    public static AuthorizedBackendClient prepareWithBearerToken(HttpClient httpClient, String bearerToken) {
         return new AuthorizedBackendClient(httpClient, bearerToken, null);
     }
 

--- a/auth/src/main/java/no/unit/nva/auth/CognitoCredentials.java
+++ b/auth/src/main/java/no/unit/nva/auth/CognitoCredentials.java
@@ -1,0 +1,30 @@
+package no.unit.nva.auth;
+
+import java.net.URI;
+
+public class CognitoCredentials {
+
+    private final String cognitoAppClientId;
+    private final String cognitoAppClientSecret;
+    private final URI cognitoOAuthServerUri;
+
+    public CognitoCredentials(String cognitoAppClientId,
+                              String cognitoAppClientSecret,
+                              URI cognitoOAuthServerUri) {
+        this.cognitoAppClientId = cognitoAppClientId;
+        this.cognitoAppClientSecret = cognitoAppClientSecret;
+        this.cognitoOAuthServerUri = cognitoOAuthServerUri;
+    }
+
+    public URI getCognitoOAuthServerUri() {
+        return cognitoOAuthServerUri;
+    }
+
+    public String getCognitoAppClientId() {
+        return cognitoAppClientId;
+    }
+
+    public String getCognitoAppClientSecret() {
+        return cognitoAppClientSecret;
+    }
+}

--- a/auth/src/test/java/no/unit/nva/auth/AuthorizedBackendClientTest.java
+++ b/auth/src/test/java/no/unit/nva/auth/AuthorizedBackendClientTest.java
@@ -1,6 +1,6 @@
 package no.unit.nva.auth;
 
-import static no.unit.nva.auth.AuthorizedBackendClient.prepareWithBackendCredentials;
+import static no.unit.nva.auth.AuthorizedBackendClient.prepareWithCognitoCredentials;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
@@ -41,7 +41,7 @@ class AuthorizedBackendClientTest {
     @Test
     void shouldSendRequestsContainingTheBackendAccessTokenWhenUserAccessTokenIsNotSubmitted()
         throws IOException, InterruptedException {
-        var client = prepareWithBackendCredentials(httpClient, cognitoCredentials);
+        var client = prepareWithCognitoCredentials(httpClient, cognitoCredentials);
         var resourceUri = UriWrapper.fromUri(serverUri).addChild(EXAMPLE_RESOURCE_PATH).getUri();
         var request = HttpRequest.newBuilder(resourceUri).GET();
         var response = client.send(request, BodyHandlers.ofString(StandardCharsets.UTF_8));
@@ -50,7 +50,7 @@ class AuthorizedBackendClientTest {
 
     @Test
     void shouldSendAsyncRequestsContainingTheAccessTokenWhenUserAccessTokenIsNotSubmitted() {
-        var client = prepareWithBackendCredentials(httpClient, cognitoCredentials);
+        var client = prepareWithCognitoCredentials(httpClient, cognitoCredentials);
         var resourceUri = UriWrapper.fromUri(serverUri).addChild(EXAMPLE_RESOURCE_PATH).getUri();
         var request = HttpRequest.newBuilder(resourceUri).GET();
         var response =
@@ -62,7 +62,7 @@ class AuthorizedBackendClientTest {
     void shouldSendRequestsContainingTheUserAccessTokenWhenUserAccessTokenIsSubmitted()
         throws IOException, InterruptedException {
         String bearerToken = "Bearer " + expectedAccessToken;
-        var client = AuthorizedBackendClient.prepareWithUserCredentials(httpClient, bearerToken);
+        var client = AuthorizedBackendClient.prepareWithBearerToken(httpClient, bearerToken);
         var resourceUri = UriWrapper.fromUri(serverUri).addChild(EXAMPLE_RESOURCE_PATH).getUri();
         var request = HttpRequest.newBuilder(resourceUri).GET();
 

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.23.0-alpha1'
+version = '1.24.0-alpha1'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Remove the requirement for reading Cognito Credentials from env variables.

Reading from Env variables makes this more difficult because and has implications with deployment when the secrets are updated.