### PR TITLE
Extract bucket name

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.25.9'
+version = '1.25.10'
 
 
 repositories {

--- a/eventhandlers/src/main/java/no/unit/nva/events/models/EventReference.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/models/EventReference.java
@@ -75,6 +75,10 @@ public class EventReference implements JsonSerializable, EventBody {
         return uri;
     }
     
+    public String extractBucketName() {
+        return uri.getHost();
+    }
+    
     @Override
     @JacocoGenerated
     public boolean equals(Object o) {

--- a/eventhandlers/src/test/java/no/unit/nva/events/models/EventReferenceTest.java
+++ b/eventhandlers/src/test/java/no/unit/nva/events/models/EventReferenceTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
 import java.net.URI;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 class EventReferenceTest {
@@ -20,7 +21,7 @@ class EventReferenceTest {
         assertThat(json, containsString(expectedTopic));
         assertThat(json, containsString(expectedUri.toString()));
     }
-
+    
     @Test
     void shouldDeSerializeFromJsonObjectWithoutInformationLoss() {
         String expectedTopic = randomString();
@@ -28,5 +29,12 @@ class EventReferenceTest {
         EventReference eventReference = new EventReference(expectedTopic, expectedUri);
         EventReference deserializedEventReference = EventReference.fromJson(eventReference.toJsonString());
         assertThat(deserializedEventReference, is(equalTo(eventReference)));
+    }
+    
+    @Test
+    void shouldProvideBucketNameContainingTheEvent() {
+        var s3uri = URI.create("s3://expected-bucket/path/to/file");
+        var eventReference = new EventReference(randomString(), randomString(), s3uri, Instant.now());
+        assertThat(eventReference.extractBucketName(), is(equalTo("expected-bucket")));
     }
 }


### PR DESCRIPTION
When creating an S3Driver we need to know the bucket name that contains the event. This is in cases where the events bucket is not known a priori from the handler (such is the case of the crisistin import handlers.Other cases may also arise in the future