### PR TITLE
Fix media type handling for schema org

### DIFF
--- a/apigateway/src/main/java/nva/commons/apigateway/MediaTypes.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/MediaTypes.java
@@ -4,13 +4,14 @@ import com.google.common.net.MediaType;
 
 public final class MediaTypes {
 
-    public static final MediaType APPLICATION_JSON_LD = MediaType.create("application", "ld+json");
+    public static final String APPLICATION = "application";
+    public static final MediaType APPLICATION_JSON_LD = MediaType.create(APPLICATION, "ld+json");
     public static final MediaType APPLICATION_PROBLEM_JSON =
-        MediaType.create("application", "problem+json");
+        MediaType.create(APPLICATION, "problem+json");
     public static final MediaType APPLICATION_DATACITE_XML =
-        MediaType.create("application", "vnd.datacite.datacite+xml");
+        MediaType.create(APPLICATION, "vnd.datacite.datacite+xml");
     public static final MediaType SCHEMA_ORG =
-        MediaType.create("application", "vnd.schemaorg.ld+json");
+        MediaType.create(APPLICATION, "vnd.schemaorg.ld+json");
 
     private MediaTypes() {
     }

--- a/apigateway/src/main/java/nva/commons/apigateway/MediaTypes.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/MediaTypes.java
@@ -9,6 +9,8 @@ public final class MediaTypes {
         MediaType.create("application", "problem+json");
     public static final MediaType APPLICATION_DATACITE_XML =
         MediaType.create("application", "vnd.datacite.datacite+xml");
+    public static final MediaType SCHEMA_ORG =
+        MediaType.create("application", "vnd.schemaorg.ld+json");
 
     private MediaTypes() {
     }

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
@@ -144,7 +144,7 @@ class ApiGatewayHandlerTest {
         "*/*",
         "application/json",
         "application/json; charset=UTF-8",
-        "text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8",
+        "text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8"
     })
     public void handleRequestShouldReturnOkOnSupportedAcceptHeader(String mediaType) throws IOException {
         InputStream input = requestWithAcceptHeader(mediaType);

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.25.15'
+version = '1.25.16'
 
 
 repositories {

--- a/s3/build.gradle
+++ b/s3/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation libs.aws.sdk2.core
     implementation libs.aws.ion
 
-    implementation libs.jackson.databind
+    implementation libs.bundles.jackson
     implementation libs.aws.apache.client
 
     testImplementation libs.bundles.testing

--- a/secrets/build.gradle
+++ b/secrets/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation libs.bundles.logging
     implementation libs.aws.lambda.core
 
-    implementation libs.jackson.databind
+    implementation libs.bundles.jackson
 
     testImplementation libs.bundles.testing
     testImplementation project(":logutils")


### PR DESCRIPTION
- Adds support for the mediatype used for schema.org representations by DataCite
- Improves the testing for mediatypes
- Fixes errors occurring during build due to lacking jackson extensions