### PR TITLE
Add access rights for publishing

### DIFF
--- a/apigateway/src/main/java/nva/commons/apigateway/AccessRight.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/AccessRight.java
@@ -11,6 +11,8 @@ import nva.commons.apigateway.exceptions.InvalidAccessRightException;
 public enum AccessRight {
 
     USER,// pseudo access-right to indicate the customer in cognito groups
+    PUBLISH_FILES,
+    PUBLISH_METADATA,
     APPROVE_DOI_REQUEST,
     REJECT_DOI_REQUEST,
     READ_DOI_REQUEST,

--- a/apigateway/src/test/java/nva/commons/apigateway/AccessRightTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/AccessRightTest.java
@@ -23,7 +23,7 @@ class AccessRightTest {
     }
 
     @Test
-    void fromStringThrowsExceptoinWhenInputIsInvalidAccessRight() {
+    void fromStringThrowsExceptionWhenInputIsInvalidAccessRight() {
         String invalidAccessRight = "invalidAccessRight";
         Executable action = () -> AccessRight.fromString(invalidAccessRight);
         InvalidAccessRightException exception = assertThrows(InvalidAccessRightException.class, action);

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.25.17'
+version = '1.25.18'
 
 
 repositories {


### PR DESCRIPTION
- Adds two access rights, which may be set dependent on the chosen publishing workflow for an institution:
  - PUBLISH_METADATA: when the workflow allows [sic] registrators to publish metadata only, or can publish files and metadata
  - PUBLISH_FILES: when the workflow allows [sic] registrator to publish files
- Fixed typo in test 