### PR TITLE
fix: s3Driver lists files only of selected folder and not of similar folders

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.27.0'
+version = '1.27.1'
 
 
 repositories {

--- a/core/src/main/java/nva/commons/core/paths/UnixPath.java
+++ b/core/src/main/java/nva/commons/core/paths/UnixPath.java
@@ -5,7 +5,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.StringUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/core/src/main/java/nva/commons/core/paths/UnixPath.java
+++ b/core/src/main/java/nva/commons/core/paths/UnixPath.java
@@ -1,21 +1,15 @@
 package nva.commons.core.paths;
 
-import static java.util.Objects.nonNull;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import nva.commons.core.JacocoGenerated;
+import nva.commons.core.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import nva.commons.core.JacocoGenerated;
-import nva.commons.core.StringUtils;
+import static java.util.Objects.nonNull;
 
 /**
  * Class for manipulating Unix-like paths. Provides a standard way to add children to the paths so that we do not have
@@ -168,6 +162,16 @@ public final class UnixPath {
         return pathIsEmpty(path);
     }
 
+    public boolean startsWith(UnixPath ancestor) {
+        var currentPath = this;
+        var foundAncestor = currentPath.equals(ancestor);
+        while (!foundAncestor && !currentPath.isEmptyPath()) {
+            currentPath = currentPath.getParent().orElse(UnixPath.EMPTY_PATH);
+            foundAncestor = currentPath.equals(ancestor);
+        }
+        return foundAncestor;
+    }
+
     private boolean isAbsolute() {
         return !isEmptyPath() && ROOT.equals(path.get(0));
     }
@@ -184,14 +188,6 @@ public final class UnixPath {
         return ROOT + formatPathAsString(path.subList(1, path.size()));
     }
 
-    public boolean startsWith(UnixPath ancestor) {
-        var currentPath = this;
-        var foundAncestor = currentPath.equals(ancestor);
-        while (!foundAncestor && !currentPath.isEmptyPath()) {
-            currentPath = currentPath.getParent().orElse(UnixPath.EMPTY_PATH);
-            foundAncestor = currentPath.equals(ancestor);
-        }
-        return foundAncestor;
-    }
+
 
 }

--- a/nvatestutils/src/main/java/no/unit/nva/stubs/FakeS3Client.java
+++ b/nvatestutils/src/main/java/no/unit/nva/stubs/FakeS3Client.java
@@ -139,7 +139,7 @@ public class FakeS3Client implements S3Client {
         
         return parentFolder.isEmptyPath()
                || parentFolder.isRoot()
-               || filePath.toString().startsWith(parentFolder.toString());
+               || filePath.startsWith(parentFolder);
     }
     
     private int calculateEndIndex(List<String> fileKeys, String marker, Integer pageSize) {


### PR DESCRIPTION
Bug Description:

Currently
 Given that there are two folders "hello" and "hello-world" 
 When `S3Driver.listAllFiles(UnixPath.of("hello"))` is called 
 Then data from both "hello" and "hello-world" are returned

After fix:
 Given that there are two folders "hello" and "hello-world" 
 When `S3Driver.listAllFiles(UnixPath.of("hello"))` is called 
 Then data  ONLY FROM  "hello" are returned
