### PR TITLE
or-else-throw with exception only

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.27.2'
+version = '1.27.3'
 
 
 repositories {

--- a/core/src/main/java/nva/commons/core/attempt/Failure.java
+++ b/core/src/main/java/nva/commons/core/attempt/Failure.java
@@ -75,7 +75,6 @@ public class Failure<T> extends Try<T> {
             throw new IllegalStateException(NULL_ACTION_MESSAGE);
         }
     }
-
     @Override
     public <E extends Exception> Optional<T> toOptional(ConsumerWithException<Failure<T>, E> action) throws E {
         action.consume(this);

--- a/core/src/main/java/nva/commons/core/attempt/Try.java
+++ b/core/src/main/java/nva/commons/core/attempt/Try.java
@@ -5,6 +5,8 @@ import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static java.util.Objects.isNull;
+
 /**
  * Utility class for handling checked exceptions in map functions. Check tests for examples
  *
@@ -76,6 +78,13 @@ public abstract class Try<T> {
     public abstract <E extends Exception> Try<Void> forEach(ConsumerWithException<T, E> consumer);
 
     public abstract <E extends Exception> T orElseThrow(Function<Failure<T>, E> action) throws E;
+
+    public T orElseThrow(RuntimeException e)  {
+        if(isNull(e)){
+            throw new IllegalStateException("Supplied exception is null");
+        }
+        return orElseThrow(fail -> e);
+    }
 
     public abstract T orElseThrow();
 

--- a/core/src/main/java/nva/commons/core/attempt/Try.java
+++ b/core/src/main/java/nva/commons/core/attempt/Try.java
@@ -5,8 +5,6 @@ import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static java.util.Objects.isNull;
-
 /**
  * Utility class for handling checked exceptions in map functions. Check tests for examples
  *
@@ -80,9 +78,6 @@ public abstract class Try<T> {
     public abstract <E extends Exception> T orElseThrow(Function<Failure<T>, E> action) throws E;
 
     public T orElseThrow(RuntimeException e)  {
-        if(isNull(e)){
-            throw new IllegalStateException("Supplied exception is null");
-        }
         return orElseThrow(fail -> e);
     }
 

--- a/core/src/test/java/nva/commons/core/attempt/FailureTest.java
+++ b/core/src/test/java/nva/commons/core/attempt/FailureTest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -34,7 +35,7 @@ public class FailureTest {
         Executable action =
             () -> Try.of(sample)
                 .map(i -> throwCheckedException(NOT_EXPECTED_MESSAGE))
-                .orElseThrow(null);
+                .orElseThrow((Function<Failure<Integer>, ? extends Exception>) null);
         IllegalStateException exception = assertThrows(IllegalStateException.class, action);
         assertThat(exception.getMessage(), is(equalTo(Failure.NULL_ACTION_MESSAGE)));
     }

--- a/core/src/test/java/nva/commons/core/attempt/SuccessTest.java
+++ b/core/src/test/java/nva/commons/core/attempt/SuccessTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +30,7 @@ public class SuccessTest {
     public void orElseThrowsIllegalStateExceptionForNullArgument() {
 
         Executable action =
-            () -> Try.of(sample).orElseThrow(null);
+            () -> Try.of(sample).orElseThrow((Function<Failure<Integer>, ? extends Exception>) null);
         IllegalStateException exception = assertThrows(IllegalStateException.class, action);
         assertThat(exception.getMessage(), is(equalTo(Failure.NULL_ACTION_MESSAGE)));
     }


### PR DESCRIPTION
### Description
One of the most common patterns of Try is 

```
attempt(()->someAction()).orElseThrow(fail->new IllegalStateException("Something improbable happened here"))
``` 

Think for example parsing an Enum where having an invalid value is improbable. This pattern makes it necessary to test for the improbable value because of the code coverage rules. Sometimes it is very difficult to inject an illegal value during testing so  then we will write

```
attempt(()->someAction()).orElseThrow()
``` 
The above throws a RuntimeException with no explanatory message. In addition throwing a plain RuntimeException is kind of an anti-pattern.

### Suggested Change
The suggested change is implementing the following pattern:

```
attempt(()->someAction()).orElseThrow(new IllegalStateException("Something improbable happened"))
``` 

### Benefits
We avoid having to test impossible situations and at the same time we can give a more detailed message if the improbable happens.

### Example:
Consider the following code:

```
public enum MediaSubTypeEnum {
    
    JOURNAL("Journal"),
    RADIO("Radio"),
    TV("TV"),
    INTERNET("Internet"),
    OTHER("Other");
    
    private String value;
    
    MediaSubTypeEnum(String value) {
        this.value = value;
    }
    
    @JsonCreator
    public static MediaSubTypeEnum parse(String candidate) {
        return Arrays.stream(MediaSubTypeEnum.values())
                   .filter(subType -> subType.value.equalsIgnoreCase(candidate))
                   .collect(SingletonCollector.collect());
    }
```
 If an illegal value is inserted we will not get an informative message. If we use the 
`.orElseThrow(fail-> new  IllegalStateException("someMessage"))` then we have to write unit tests for that Enum.
But if we use the suggested change `orElseThrow(new IllegalStateException("someMessage") we get both the informative message and Jacoco is happy
