### PR TITLE
ignore previous event in AwsEventBridgeDetail

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.27.6'
+version = '1.27.7'
 
 
 repositories {

--- a/eventhandlers/src/main/java/no/unit/nva/events/models/AwsEventBridgeDetail.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/models/AwsEventBridgeDetail.java
@@ -1,10 +1,12 @@
 package no.unit.nva.events.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Objects;
 import nva.commons.core.JacocoGenerated;
 
+@JsonIgnoreProperties("requestPayload")
 public class AwsEventBridgeDetail<I> {
 
     @JsonProperty("version")

--- a/eventhandlers/src/main/java/no/unit/nva/events/models/EventReference.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/models/EventReference.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.Objects;
 import no.unit.nva.commons.json.JsonSerializable;
+import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.core.JacocoGenerated;
 
 /**
@@ -16,7 +17,7 @@ import nva.commons.core.JacocoGenerated;
  * of the event
  */
 public class EventReference implements JsonSerializable, EventBody {
-    
+
     public static final String TOPIC = "topic";
     public static final String URI = "uri";
     public static final String SUBTOPIC = "subtopic";
@@ -29,7 +30,7 @@ public class EventReference implements JsonSerializable, EventBody {
     private final URI uri;
     @JsonProperty(TIMESTAMP)
     private final Instant timestamp;
-    
+
     @JsonCreator
     public EventReference(@JsonProperty(TOPIC) String topic,
                           @JsonProperty(SUBTOPIC) String subtopic,
@@ -40,45 +41,55 @@ public class EventReference implements JsonSerializable, EventBody {
         this.uri = uri;
         this.timestamp = timestamp;
     }
-    
+
     public EventReference(String topic,
                           String subtopic,
                           URI uri) {
         this(topic, subtopic, uri, Instant.now());
     }
-    
+
     public EventReference(String topic, URI uri) {
         this(topic, null, uri);
     }
-    
+
     public static EventReference fromJson(String json) {
         return attempt(() -> objectMapper.readValue(json, EventReference.class)).orElseThrow();
     }
-    
+
     public Instant getTimestamp() {
         return timestamp;
     }
-    
+
     @JacocoGenerated
     public String getSubtopic() {
         return subtopic;
     }
-    
+
     @Override
     @JacocoGenerated
     public String getTopic() {
         return topic;
     }
-    
+
     @JacocoGenerated
     public URI getUri() {
         return uri;
     }
-    
+
     public String extractBucketName() {
         return uri.getHost();
     }
-    
+
+
+    @Override
+    public String toJsonString() {
+        try {
+            return JsonUtils.singleLineObjectMapper.writeValueAsString(this);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     @JacocoGenerated
     public boolean equals(Object o) {
@@ -93,7 +104,7 @@ public class EventReference implements JsonSerializable, EventBody {
             that.getSubtopic()) && Objects.equals(getUri(), that.getUri()) && Objects.equals(
             getTimestamp(), that.getTimestamp());
     }
-    
+
     @Override
     @JacocoGenerated
     public int hashCode() {


### PR DESCRIPTION
When a lambda handler is triggered through Lambda destinations the event details contain in the "requestPayload" all the previous events. Since we are not using the field it is better to explicitly ignore it.