### PR TITLE
Add identifier to events

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.28.0'
+version = '1.28.1'
 
 
 repositories {

--- a/eventhandlers/src/main/java/no/unit/nva/events/handlers/StartBatchScanHandler.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/handlers/StartBatchScanHandler.java
@@ -42,7 +42,8 @@ public abstract class StartBatchScanHandler implements RequestStreamHandler {
     private ScanDatabaseRequest createEventAsExpectedByEventListener(ScanDatabaseRequest input) {
         return new ScanDatabaseRequest(getScanEventTopic(),
                                        input.getPageSize(),
-                                       input.getStartMarker());
+                                       input.getStartMarker(),
+                                       input.getIdentifier());
     }
 
     private void emitEvent(Context context, ScanDatabaseRequest requestWithTopic) {

--- a/eventhandlers/src/main/java/no/unit/nva/events/models/EventBody.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/models/EventBody.java
@@ -1,11 +1,16 @@
 package no.unit.nva.events.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
 
 public interface EventBody {
 
-    String TOPIC = "topic";
+    String TOPIC_FIELD = "topic";
+    String IDENTIFIER_FIELD = "identifier";
 
-    @JsonProperty(TOPIC)
+    @JsonProperty(TOPIC_FIELD)
     String getTopic();
+
+    @JsonProperty(IDENTIFIER_FIELD)
+    UUID getIdentifier();
 }

--- a/eventhandlers/src/main/java/no/unit/nva/events/models/EventReference.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/models/EventReference.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.UUID;
 import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.core.JacocoGenerated;
@@ -30,24 +31,42 @@ public class EventReference implements JsonSerializable, EventBody {
     private final URI uri;
     @JsonProperty(TIMESTAMP)
     private final Instant timestamp;
+    @JsonProperty(IDENTIFIER_FIELD)
+    private final UUID identifier;
 
     @JsonCreator
     public EventReference(@JsonProperty(TOPIC) String topic,
                           @JsonProperty(SUBTOPIC) String subtopic,
                           @JsonProperty(URI) URI uri,
-                          @JsonProperty(TIMESTAMP) Instant timestamp) {
+                          @JsonProperty(TIMESTAMP) Instant timestamp,
+                          @JsonProperty(IDENTIFIER_FIELD) UUID identifier) {
         this.topic = topic;
         this.subtopic = subtopic;
         this.uri = uri;
         this.timestamp = timestamp;
+        this.identifier = identifier;
     }
 
+    @Deprecated
+    public EventReference(String topic,
+                          String subtopic,
+                          URI uri,
+                          Instant timestamp) {
+        this(topic, subtopic, uri, timestamp, UUID.randomUUID());
+    }
+
+    @Deprecated
     public EventReference(String topic,
                           String subtopic,
                           URI uri) {
-        this(topic, subtopic, uri, Instant.now());
+        this(topic, subtopic, uri, Instant.now(), UUID.randomUUID());
     }
 
+    public EventReference(String topic, URI uri, UUID identifier) {
+        this(topic, null, uri, Instant.now(), identifier);
+    }
+
+    @Deprecated
     public EventReference(String topic, URI uri) {
         this(topic, null, uri);
     }
@@ -69,6 +88,11 @@ public class EventReference implements JsonSerializable, EventBody {
     @JacocoGenerated
     public String getTopic() {
         return topic;
+    }
+
+    @Override
+    public UUID getIdentifier() {
+        return identifier;
     }
 
     @JacocoGenerated
@@ -100,14 +124,16 @@ public class EventReference implements JsonSerializable, EventBody {
             return false;
         }
         EventReference that = (EventReference) o;
-        return Objects.equals(getTopic(), that.getTopic()) && Objects.equals(getSubtopic(),
-            that.getSubtopic()) && Objects.equals(getUri(), that.getUri()) && Objects.equals(
-            getTimestamp(), that.getTimestamp());
+        return Objects.equals(getTopic(), that.getTopic())
+               && Objects.equals(getSubtopic(), that.getSubtopic())
+               && Objects.equals(getUri(), that.getUri())
+               && Objects.equals(getTimestamp(), that.getTimestamp())
+               && Objects.equals(getIdentifier(), that.getIdentifier());
     }
 
     @Override
     @JacocoGenerated
     public int hashCode() {
-        return Objects.hash(getTopic(), getSubtopic(), getUri(), getTimestamp());
+        return Objects.hash(getTopic(), getSubtopic(), getUri(), getTimestamp(), getIdentifier());
     }
 }

--- a/eventhandlers/src/main/java/no/unit/nva/events/models/ScanDatabaseRequest.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/models/ScanDatabaseRequest.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import no.unit.nva.commons.json.JsonSerializable;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
@@ -31,19 +32,29 @@ public class ScanDatabaseRequest implements EventBody, JsonSerializable {
     private final Map<String, AttributeValue> startMarker;
     @JsonProperty(PAGE_SIZE)
     private final int pageSize;
-    @JsonProperty(TOPIC)
+    @JsonProperty(TOPIC_FIELD)
     private final String topic;
+    @JsonProperty(IDENTIFIER_FIELD)
+    private final UUID identifier;
 
     @JsonCreator
     public ScanDatabaseRequest(
-        @JsonProperty(TOPIC) String topic,
+        @JsonProperty(TOPIC_FIELD) String topic,
         @JsonProperty(PAGE_SIZE) Integer pageSize,
-        @JsonProperty(START_MARKER) Map<String, AttributeValue> startMarker) {
+        @JsonProperty(START_MARKER) Map<String, AttributeValue> startMarker,
+        @JsonProperty(IDENTIFIER_FIELD) UUID identifier) {
         this.pageSize = Optional.ofNullable(pageSize).orElse(DEFAULT_PAGE_SIZE);
         this.startMarker = startMarker;
         this.topic = topic;
+        this.identifier = identifier;
     }
 
+    @Deprecated
+    public ScanDatabaseRequest(String topic,
+                               Integer pageSize,
+                               Map<String, AttributeValue> startMarker) {
+        this(topic, pageSize, startMarker, UUID.randomUUID());
+    }
     public static ScanDatabaseRequest fromJson(String detail)
         throws JsonProcessingException {
         return objectMapper.readValue(detail, ScanDatabaseRequest.class);
@@ -53,6 +64,11 @@ public class ScanDatabaseRequest implements EventBody, JsonSerializable {
     @Override
     public String getTopic() {
         return topic;
+    }
+
+    @Override
+    public UUID getIdentifier() {
+        return identifier;
     }
 
     public int getPageSize() {
@@ -73,7 +89,7 @@ public class ScanDatabaseRequest implements EventBody, JsonSerializable {
      * @return a new ScanDatabaseRequest containing the the {@code newStartMarker}
      */
     public ScanDatabaseRequest newScanDatabaseRequest(Map<String, AttributeValue> newStartMarker) {
-        return new ScanDatabaseRequest(getTopic(), getPageSize(), newStartMarker);
+        return new ScanDatabaseRequest(getTopic(), getPageSize(), newStartMarker, getIdentifier());
     }
 
     public PutEventsRequestEntry createNewEventEntry(
@@ -94,12 +110,6 @@ public class ScanDatabaseRequest implements EventBody, JsonSerializable {
 
     @Override
     @JacocoGenerated
-    public int hashCode() {
-        return Objects.hash(getStartMarker(), getPageSize(), getTopic());
-    }
-
-    @Override
-    @JacocoGenerated
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -110,7 +120,14 @@ public class ScanDatabaseRequest implements EventBody, JsonSerializable {
         ScanDatabaseRequest that = (ScanDatabaseRequest) o;
         return getPageSize() == that.getPageSize()
                && Objects.equals(getStartMarker(), that.getStartMarker())
-               && Objects.equals(getTopic(), that.getTopic());
+               && Objects.equals(getTopic(), that.getTopic())
+               && Objects.equals(getIdentifier(), that.getIdentifier());
+    }
+
+    @Override
+    @JacocoGenerated
+    public int hashCode() {
+        return Objects.hash(getStartMarker(), getPageSize(), getTopic(), getIdentifier());
     }
 
     private boolean pageSizeWithinLimits(int pageSize) {

--- a/eventhandlers/src/main/java/no/unit/nva/events/models/ScanDatabaseRequestV2.java
+++ b/eventhandlers/src/main/java/no/unit/nva/events/models/ScanDatabaseRequestV2.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -33,17 +34,25 @@ public class ScanDatabaseRequestV2 implements EventBody {
     private Map<String, String> startMarker;
     @JsonProperty(PAGE_SIZE)
     private Integer pageSize;
-    @JsonProperty(TOPIC)
+    @JsonProperty(TOPIC_FIELD)
     private String topic;
+    @JsonProperty(IDENTIFIER_FIELD)
+    private UUID identifier;
 
     public ScanDatabaseRequestV2() {
 
     }
 
-    public ScanDatabaseRequestV2(String topic, Integer pageSize, Map<String, String> startMarker) {
+    public ScanDatabaseRequestV2(String topic, Integer pageSize, Map<String, String> startMarker, UUID identifier) {
         setPageSize(pageSize);
         setTopic(topic);
         setStartMarker(startMarker);
+        setIdentifier(identifier);
+    }
+
+    @Deprecated
+    public ScanDatabaseRequestV2(String topic, Integer pageSize, Map<String, String> startMarker) {
+        this(topic, pageSize, startMarker, UUID.randomUUID());
     }
 
     public static ScanDatabaseRequestV2 fromJson(String detail) {
@@ -67,12 +76,21 @@ public class ScanDatabaseRequestV2 implements EventBody {
     }
 
     public ScanDatabaseRequestV2 newScanDatabaseRequest(Map<String, AttributeValue> newStartMarker) {
-        return new ScanDatabaseRequestV2(getTopic(), getPageSize(), toSerializableForm(newStartMarker));
+        return new ScanDatabaseRequestV2(getTopic(), getPageSize(), toSerializableForm(newStartMarker), getIdentifier());
     }
 
     @Override
     public String getTopic() {
         return topic;
+    }
+
+    @Override
+    public UUID getIdentifier() {
+        return identifier;
+    }
+
+    private void setIdentifier(UUID identifier) {
+        this.identifier = identifier;
     }
 
     public final void setTopic(String topic) {
@@ -103,14 +121,8 @@ public class ScanDatabaseRequestV2 implements EventBody {
             .build();
     }
 
-    @JacocoGenerated
     @Override
-    public int hashCode() {
-        return Objects.hash(getStartMarker(), getPageSize(), getTopic());
-    }
-
     @JacocoGenerated
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -119,9 +131,16 @@ public class ScanDatabaseRequestV2 implements EventBody {
             return false;
         }
         ScanDatabaseRequestV2 that = (ScanDatabaseRequestV2) o;
-        return getPageSize() == that.getPageSize()
-               && Objects.equals(getStartMarker(), that.getStartMarker())
-               && Objects.equals(getTopic(), that.getTopic());
+        return Objects.equals(getStartMarker(), that.getStartMarker())
+               && Objects.equals(getPageSize(), that.getPageSize())
+               && Objects.equals(getTopic(), that.getTopic())
+               && Objects.equals(getIdentifier(), that.getIdentifier());
+    }
+
+    @Override
+    @JacocoGenerated
+    public int hashCode() {
+        return Objects.hash(getStartMarker(), getPageSize(), getTopic(), getIdentifier());
     }
 
     @Override

--- a/eventhandlers/src/test/java/no/unit/nva/events/handlers/StartBatchScanHandlerTest.java
+++ b/eventhandlers/src/test/java/no/unit/nva/events/handlers/StartBatchScanHandlerTest.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
+import java.util.UUID;
 import no.unit.nva.events.models.ScanDatabaseRequest;
 import no.unit.nva.stubs.FakeEventBridgeClient;
 import nva.commons.core.SingletonCollector;
@@ -99,17 +100,17 @@ class StartBatchScanHandlerTest {
     }
 
     private InputStream scanDatabaseRequestWithCustomTopic(String userDefinedTopic) {
-        var request = new ScanDatabaseRequest(userDefinedTopic, NO_PAGE_SIZE, NO_START_MARKER);
+        var request = new ScanDatabaseRequest(userDefinedTopic, NO_PAGE_SIZE, NO_START_MARKER, UUID.randomUUID());
         return IoUtils.stringToStream(request.toJsonString());
     }
 
     private InputStream scanDatabaseRequestWithStartMarker() {
-        var request = new ScanDatabaseRequest(randomString(), randomPageSize, randomStartMarker);
+        var request = new ScanDatabaseRequest(randomString(), randomPageSize, randomStartMarker, UUID.randomUUID());
         return IoUtils.stringToStream(request.toJsonString());
     }
 
     private InputStream scanDatabaseRequestWithPageSize() {
-        var request = new ScanDatabaseRequest(randomString(), randomPageSize, null);
+        var request = new ScanDatabaseRequest(randomString(), randomPageSize, null, UUID.randomUUID());
         return IoUtils.stringToStream(request.toJsonString());
     }
 

--- a/eventhandlers/src/test/java/no/unit/nva/events/models/EventReferenceTest.java
+++ b/eventhandlers/src/test/java/no/unit/nva/events/models/EventReferenceTest.java
@@ -1,22 +1,38 @@
 package no.unit.nva.events.models;
 
+import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.StringContains.containsString;
 import java.net.URI;
 import java.time.Instant;
+import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class EventReferenceTest {
+
+    @Deprecated
+    public static Stream<EventReference> deprecatedMethodProvider() {
+        return Stream.of(
+            new EventReference(randomString(), randomString(), randomUri(), randomInstant()),
+            new EventReference(randomString(), randomUri())
+        );
+    }
 
     @Test
     void shouldSerializeToJsonObjectThatContainsTopicAndUri() {
         String expectedTopic = randomString();
         URI expectedUri = randomUri();
-        EventReference eventReference = new EventReference(expectedTopic, expectedUri);
+        EventReference eventReference = new EventReference(expectedTopic, expectedUri, UUID.randomUUID());
         String json = eventReference.toJsonString();
         assertThat(json, containsString(expectedTopic));
         assertThat(json, containsString(expectedUri.toString()));
@@ -26,7 +42,7 @@ class EventReferenceTest {
     void shouldDeSerializeFromJsonObjectWithoutInformationLoss() {
         String expectedTopic = randomString();
         URI expectedUri = randomUri();
-        EventReference eventReference = new EventReference(expectedTopic, expectedUri);
+        EventReference eventReference = new EventReference(expectedTopic, expectedUri, UUID.randomUUID());
         EventReference deserializedEventReference = EventReference.fromJson(eventReference.toJsonString());
         assertThat(deserializedEventReference, is(equalTo(eventReference)));
     }
@@ -34,7 +50,15 @@ class EventReferenceTest {
     @Test
     void shouldProvideBucketNameContainingTheEvent() {
         var s3uri = URI.create("s3://expected-bucket/path/to/file");
-        var eventReference = new EventReference(randomString(), randomString(), s3uri, Instant.now());
+        var eventReference = new EventReference(randomString(), randomString(), s3uri,
+                                                Instant.now(), UUID.randomUUID());
         assertThat(eventReference.extractBucketName(), is(equalTo("expected-bucket")));
+    }
+
+    @Deprecated
+    @ParameterizedTest(name = "Should ensure deprecated constructors have unique Identifiers")
+    @MethodSource("deprecatedMethodProvider")
+    void shouldHaveIdentifierWhenDeprecatedMethodIsUsed(EventReference eventReference) {
+        assertThat(eventReference.getIdentifier(), is(not(nullValue())));
     }
 }

--- a/eventhandlers/src/test/java/no/unit/nva/events/models/ScanDatabaseRequestTest.java
+++ b/eventhandlers/src/test/java/no/unit/nva/events/models/ScanDatabaseRequestTest.java
@@ -5,10 +5,13 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.events.EventsConfig;
 import org.junit.jupiter.api.Test;
@@ -20,7 +23,7 @@ class ScanDatabaseRequestTest {
     @Test
     void shouldReturnAnEventBridgeEventWhereTheTopicIsSetInTheDetailBody() throws JsonProcessingException {
         String expectedTopic = randomString();
-        var request = new ScanDatabaseRequest(expectedTopic, 100, null);
+        var request = new ScanDatabaseRequest(expectedTopic, 100, null, UUID.randomUUID());
         var event = request.createNewEventEntry(randomString(), randomString(), randomString());
         var eventAsJson = EventsConfig.objectMapper.readTree(event.detail());
         assertThat(eventAsJson.get(EVENT_TOPIC).textValue(), is(equalTo(expectedTopic)));
@@ -28,7 +31,7 @@ class ScanDatabaseRequestTest {
 
     @Test
     void shouldReturnScanRequestFromEventDetail() throws JsonProcessingException {
-        var originalRequest = new ScanDatabaseRequest(randomString(), randomInteger(), null);
+        var originalRequest = new ScanDatabaseRequest(randomString(), randomInteger(), null, UUID.randomUUID());
         var event = originalRequest.createNewEventEntry(randomString(), randomString(), randomString());
         var reconstructedRequest =
             ScanDatabaseRequest.fromJson(event.detail());
@@ -37,7 +40,7 @@ class ScanDatabaseRequestTest {
 
     @Test
     void shouldGenerateNewEventWithSameTopicAndPageSize() {
-        var originalRequest = new ScanDatabaseRequest(randomString(), randomInteger(), null);
+        var originalRequest = new ScanDatabaseRequest(randomString(), randomInteger(), null, UUID.randomUUID());
         var expectedStartMarker = Map.of(randomString(), new AttributeValue(randomString()),
                                          randomString(), new AttributeValue(randomString()));
         var newRequest = originalRequest.newScanDatabaseRequest(expectedStartMarker);
@@ -49,8 +52,14 @@ class ScanDatabaseRequestTest {
         var deserializedFromEmptyJson = objectMapperWithoutSpecialConfig()
             .readValue(emptyJson(), ScanDatabaseRequest.class);
         var expectedDeserializedObject =
-            new ScanDatabaseRequest(null, ScanDatabaseRequest.DEFAULT_PAGE_SIZE, null);
+            new ScanDatabaseRequest(null, ScanDatabaseRequest.DEFAULT_PAGE_SIZE, null, null);
         assertThat(deserializedFromEmptyJson, is(equalTo(expectedDeserializedObject)));
+    }
+
+    @Deprecated
+    @Test
+    void shouldSupportDeprecatedMethod() {
+        assertDoesNotThrow(() -> new ScanDatabaseRequest(randomString(), randomInteger(), Collections.emptyMap()));
     }
 
     private String emptyJson() {

--- a/eventhandlers/src/test/java/no/unit/nva/events/models/ScanDatabaseRequestV2Test.java
+++ b/eventhandlers/src/test/java/no/unit/nva/events/models/ScanDatabaseRequestV2Test.java
@@ -8,9 +8,10 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
+import java.util.UUID;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.events.EventsConfig;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,7 @@ class ScanDatabaseRequestV2Test {
     @Test
     void shouldReturnAnEventBridgeEventWhereTheTopicIsSetInTheDetailBody() throws JsonProcessingException {
         String expectedTopic = randomString();
-        var request = new ScanDatabaseRequestV2(expectedTopic, 100, null);
+        var request = new ScanDatabaseRequestV2(expectedTopic, 100, null, UUID.randomUUID());
         var event = request.createNewEventEntry(randomString(), randomString(), randomString());
         var eventAsJson = EventsConfig.objectMapper.readTree(event.detail());
         assertThat(eventAsJson.get(EVENT_TOPIC).textValue(), is(equalTo(expectedTopic)));
@@ -34,7 +35,7 @@ class ScanDatabaseRequestV2Test {
 
     @Test
     void shouldReturnScanRequestFromEventDetail() {
-        var originalRequest = new ScanDatabaseRequestV2(randomString(), randomInteger(), null);
+        var originalRequest = new ScanDatabaseRequestV2(randomString(), randomInteger(), null, UUID.randomUUID());
         var event = originalRequest.createNewEventEntry(randomString(), randomString(), randomString());
         var reconstructedRequest =
             ScanDatabaseRequestV2.fromJson(event.detail());
@@ -44,7 +45,7 @@ class ScanDatabaseRequestV2Test {
     @Test
     void shouldGenerateNewEventWithSameTopicAndPageSize() {
         var originalRequest =
-            new ScanDatabaseRequestV2(randomString(), randomInteger(MAX_PAGE_SIZE), null);
+            new ScanDatabaseRequestV2(randomString(), randomInteger(MAX_PAGE_SIZE), null, UUID.randomUUID());
         var expectedStartMarker = Map.of(randomString(), randomStringAttribute(),
                                          randomString(), randomStringAttribute());
         var newRequest = originalRequest.newScanDatabaseRequest(expectedStartMarker);
@@ -52,10 +53,10 @@ class ScanDatabaseRequestV2Test {
     }
 
     @Test
-    void shouldDeserializeEmptyObject() throws JsonProcessingException {
+    void shouldDeserializeEmptyObject() {
         var deserializedFromEmptyJson = ScanDatabaseRequestV2.fromJson(emptyJson());
         var expectedDeserializedObject =
-            new ScanDatabaseRequestV2(null, ScanDatabaseRequestV2.DEFAULT_PAGE_SIZE, null);
+            new ScanDatabaseRequestV2(null, ScanDatabaseRequestV2.DEFAULT_PAGE_SIZE, null, null);
         assertThat(deserializedFromEmptyJson, is(equalTo(expectedDeserializedObject)));
     }
 
@@ -65,9 +66,11 @@ class ScanDatabaseRequestV2Test {
         var expectedStartMarker = Map.of(randomString(), randomString(),
                                          randomString(), randomString());
         var expectedTopic = randomString();
+        var identifier = UUID.randomUUID();
         var actualRequest =
-            new ScanDatabaseRequestV2(expectedTopic, pageSize, expectedStartMarker);
-        var expectedRequest = new ScanDatabaseRequestV2(expectedTopic, DEFAULT_PAGE_SIZE, expectedStartMarker);
+            new ScanDatabaseRequestV2(expectedTopic, pageSize, expectedStartMarker, identifier);
+        var expectedRequest =
+            new ScanDatabaseRequestV2(expectedTopic, DEFAULT_PAGE_SIZE, expectedStartMarker, identifier);
 
         assertThat(actualRequest, is(equalTo(expectedRequest)));
     }
@@ -75,21 +78,27 @@ class ScanDatabaseRequestV2Test {
     @Test
     void shouldSerializeAndDeserializeWithoutInformationLoss() {
         var startMarker = randomMarker();
-        var sampleRequest = new ScanDatabaseRequestV2(randomString(), randomInteger(), startMarker);
+        var sampleRequest = new ScanDatabaseRequestV2(randomString(), randomInteger(), startMarker, UUID.randomUUID());
         var json = sampleRequest.toString();
         var deserialized = ScanDatabaseRequestV2.fromJson(json);
         assertThat(deserialized, is(equalTo(sampleRequest)));
-        assertThatNonSerializableDynamoScanMarkerConstainsSameValuesAsItsEquivalentSerializableRepresentation(
+        assertThatNonSerializableDynamoScanMarkerContainsSameValuesAsItsEquivalentSerializableRepresentation(
             startMarker, deserialized);
     }
 
     @Test
     void shouldProduceDynamoCompatibleEmptyMarkerWhenSerializableVersionOfMarkerIsNull() {
-        var sampleRequest = new ScanDatabaseRequestV2(randomString(), randomInteger(), EMPTY_MARKER);
+        var sampleRequest = new ScanDatabaseRequestV2(randomString(), randomInteger(), EMPTY_MARKER, UUID.randomUUID());
         assertThat(sampleRequest.toDynamoScanMarker(), is(equalTo(DYNAMODB_EMPTY_MARKER)));
     }
 
-    private void assertThatNonSerializableDynamoScanMarkerConstainsSameValuesAsItsEquivalentSerializableRepresentation(
+    @Deprecated
+    @Test
+    void shouldAllowCreationOfDeprecatedScanDatabaseRequestV2() {
+        assertDoesNotThrow(() -> new ScanDatabaseRequestV2(randomString(), randomInteger(), randomMarker()));
+    }
+
+    private void assertThatNonSerializableDynamoScanMarkerContainsSameValuesAsItsEquivalentSerializableRepresentation(
         Map<String, String> startMarker, ScanDatabaseRequestV2 deserialized) {
         for (var key : startMarker.keySet()) {
             var expectedAttributeValue = startMarker.get(key);
@@ -109,9 +118,5 @@ class ScanDatabaseRequestV2Test {
 
     private String emptyJson() {
         return JsonUtils.dtoObjectMapper.createObjectNode().toString();
-    }
-
-    private ObjectMapper objectMapperWithoutSpecialConfig() {
-        return new ObjectMapper();
     }
 }


### PR DESCRIPTION
In order to allow traceability, I have added an identifier field to events.

Notes:
 - The old event constructors have been updated to add a random UUID as a temporary measure, I am not sure that we want to enforce a pattern where each event automatically has a unique identifier since we may wish to trace events from different handlers using the same identifier, i.e. we may wish to pass the same identifier to different events
 - The old constructors are marked as @Deprecated to facilitate the identification of these methods while we refactor code that uses these implementations