### PR TITLE
read file directly from S3 URI

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.29.3'
+version = '1.29.4'
 
 
 repositories {

--- a/s3/src/main/java/no/unit/nva/s3/S3Driver.java
+++ b/s3/src/main/java/no/unit/nva/s3/S3Driver.java
@@ -130,6 +130,16 @@ public class S3Driver {
      * @return the file contents uncompressed.
      */
     public String readEvent(URI uri) {
+        return readFile(uri);
+    }
+
+    /**
+     * Method for reading files from S3 bucket.
+     *
+     * @param uri the S3 URI to the file. The host must be equal to the bucket name of the S3 driver
+     * @return the file contents uncompressed.
+     */
+    public String readFile(URI uri) {
         UnixPath filePath = UriWrapper.fromUri(uri).toS3bucketPath();
         return getFile(filePath);
     }

--- a/s3/src/test/java/no/unit/nva/s3/S3DriverTest.java
+++ b/s3/src/test/java/no/unit/nva/s3/S3DriverTest.java
@@ -185,8 +185,19 @@ class S3DriverTest {
         String content = randomString();
         UnixPath someFolder = UnixPath.of("parent", "child1", "child2");
         URI fileLocation = s3Driver.insertEvent(someFolder, content);
-        String retrievedContent = s3Driver.readEvent(fileLocation);
+        String retrievedContent = s3Driver.readFile(fileLocation);
         assertThat(retrievedContent, is(equalTo(content)));
+    }
+
+    @Test
+    void shouldReadFileWhenReadingEvent() throws IOException {
+        s3Driver = new S3Driver(new FakeS3Client(), "ignoredBucketName");
+        String content = randomString();
+        UnixPath someFolder = UnixPath.of("parent", "child1", "child2");
+        URI fileLocation = s3Driver.insertEvent(someFolder, content);
+        String retrievedContentAsEvent = s3Driver.readEvent(fileLocation);
+        String retrievedContentAsFile = s3Driver.readFile(fileLocation);
+        assertThat(retrievedContentAsEvent, is(equalTo(retrievedContentAsFile)));
     }
 
     @Test


### PR DESCRIPTION
The method already exists but it is called readEvent. I kept both for clarity and backwards compatibility. I considered deprecating the "readEvent" but it is clearer to use readEvent when reading the body of an event.