### PR TITLE
CachedJwtProvider

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -15,6 +15,10 @@ dependencies {
 
     implementation libs.bundles.jacksonjr
 
+    implementation libs.com.auth0.jwt
+
+    implementation libs.aws.java.sdk.core
+
     testImplementation libs.bundles.testing
     testImplementation project(":logutils")
     testImplementation project(":nvatestutils")

--- a/auth/src/main/java/no/unit/nva/auth/CachedJwtProvider.java
+++ b/auth/src/main/java/no/unit/nva/auth/CachedJwtProvider.java
@@ -1,0 +1,33 @@
+package no.unit.nva.auth;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.time.Clock;
+import java.util.Date;
+
+public class CachedJwtProvider extends CachedValueProvider<DecodedJWT> {
+
+    private final CognitoAuthenticator cognitoAuthenticator;
+    private final Clock clock;
+
+    public CachedJwtProvider(CognitoAuthenticator cognitoAuthenticator, Clock clock) {
+        super();
+        this.cognitoAuthenticator = cognitoAuthenticator;
+        this.clock = clock;
+    }
+
+    @Override
+    protected boolean isExpired() {
+        var in5sec = clock.instant().plusMillis(5000);
+
+        var expiresAtDate = cachedValue.getExpiresAt();
+        var dateIn5Secs = Date.from(in5sec);
+
+        return expiresAtDate.before(dateIn5Secs);
+    }
+
+    @Override
+    protected DecodedJWT getNewValue() {
+        return cognitoAuthenticator.fetchBearerToken();
+    }
+}
+

--- a/auth/src/main/java/no/unit/nva/auth/CachedValueProvider.java
+++ b/auth/src/main/java/no/unit/nva/auth/CachedValueProvider.java
@@ -1,0 +1,18 @@
+package no.unit.nva.auth;
+
+public abstract class CachedValueProvider<T> {
+
+    protected T cachedValue;
+
+    public T getValue() {
+        if (cachedValue == null || isExpired()) {
+            cachedValue = getNewValue();
+        }
+        return cachedValue;
+    }
+
+    protected abstract boolean isExpired();
+
+    protected abstract T getNewValue();
+}
+

--- a/auth/src/main/java/no/unit/nva/auth/CognitoAuthenticator.java
+++ b/auth/src/main/java/no/unit/nva/auth/CognitoAuthenticator.java
@@ -1,0 +1,97 @@
+package no.unit.nva.auth;
+
+import static com.amazonaws.auth.internal.SignerConstants.AUTHORIZATION;
+import static no.unit.nva.auth.AuthorizedBackendClient.APPLICATION_X_WWW_FORM_URLENCODED;
+import static nva.commons.core.attempt.Try.attempt;
+import static org.apache.http.protocol.HTTP.CONTENT_TYPE;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.jr.ob.JSON;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Objects;
+import nva.commons.core.paths.UriWrapper;
+
+public class CognitoAuthenticator {
+
+    public static final String OAUTH2_PATH_SEGMENT = "oauth2";
+    public static final String TOKEN_PATH_SEGMENT = "token";
+    public static final String BASIC_AUTH_CREDENTIALS_TEMPLATE = "%s:%s";
+    public static final String BASIC_AUTH_HEADER_TEMPLATE = "%s %s";
+    public static final String AUTHORIZATION_ERROR_MESSAGE = "Could not authorizer client";
+    public static final String GRANT_TYPE_CLIENT_CREDENTIALS = "grant_type=client_credentials";
+    public static final String JWT_TOKEN_FIELD = "access_token";
+    private final CognitoCredentials credentials;
+    private final HttpClient httpClient;
+
+    public CognitoAuthenticator(HttpClient httpClient, CognitoCredentials credentials) {
+        this.httpClient = httpClient;
+        this.credentials = credentials;
+    }
+
+    public DecodedJWT fetchBearerToken() {
+        var tokenResponse = fetchTokenResponse();
+        return attempt(() -> tokenResponse)
+                   .map(HttpResponse::body)
+                   .map(JSON.std::mapFrom)
+                   .map(json -> json.get(JWT_TOKEN_FIELD))
+                   .toOptional()
+                   .map(Objects::toString)
+                   .map(JWT::decode)
+                   .orElseThrow();
+    }
+
+    private static URI standardOauth2TokenEndpoint(URI cognitoHost) {
+        return UriWrapper.fromUri(cognitoHost).addChild(OAUTH2_PATH_SEGMENT).addChild(TOKEN_PATH_SEGMENT).getUri();
+    }
+
+    private static HttpRequest.BodyPublisher clientCredentialsAuthType() {
+        return HttpRequest.BodyPublishers.ofString(GRANT_TYPE_CLIENT_CREDENTIALS);
+    }
+
+    private String formatAuthenticationHeaderValue() {
+        return String.format(BASIC_AUTH_CREDENTIALS_TEMPLATE,
+                             credentials.getCognitoAppClientId(),
+                             credentials.getCognitoAppClientSecret());
+    }
+
+    private String formatBasicAuthenticationHeader() {
+        return attempt(this::formatAuthenticationHeaderValue)
+                   .map(str -> Base64.getEncoder().encodeToString(str.getBytes(StandardCharsets.UTF_8)))
+                   .map(credentials -> String.format(BASIC_AUTH_HEADER_TEMPLATE, "Basic", credentials))
+                   .orElseThrow();
+    }
+
+    private HttpRequest createTokenRequest() {
+        var tokenUri = standardOauth2TokenEndpoint(credentials.getCognitoOAuthServerUri());
+        return formatRequestForJwtToken(tokenUri);
+    }
+
+    private HttpResponse<String> fetchTokenResponse() {
+        return attempt(
+            () -> this.httpClient.send(createTokenRequest(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
+        )
+                   .map(this::responseIsSuccessful)
+                   .orElseThrow();
+    }
+
+    private HttpResponse<String> responseIsSuccessful(HttpResponse<String> response) {
+        if (HttpURLConnection.HTTP_OK != response.statusCode()) {
+            throw new RuntimeException(AUTHORIZATION_ERROR_MESSAGE);
+        }
+        return response;
+    }
+
+    private HttpRequest formatRequestForJwtToken(URI tokenUri) {
+        return HttpRequest.newBuilder(tokenUri)
+                   .setHeader(AUTHORIZATION, formatBasicAuthenticationHeader())
+                   .setHeader(CONTENT_TYPE, APPLICATION_X_WWW_FORM_URLENCODED)
+                   .POST(clientCredentialsAuthType())
+                   .build();
+    }
+}

--- a/auth/src/test/java/no/unit/nva/auth/CachedJwtProviderTest.java
+++ b/auth/src/test/java/no/unit/nva/auth/CachedJwtProviderTest.java
@@ -1,0 +1,71 @@
+package no.unit.nva.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CachedJwtProviderTest {
+
+    public static final Instant TOKEN_EXPIRE_AT = Instant.parse("2006-12-03T10:15:30.00Z");
+    CachedJwtProvider cachedJwtProvider;
+    private Clock mockedClock;
+
+    private DecodedJWT jwt1 = mock(DecodedJWT.class);
+    private DecodedJWT jwt2 = mock(DecodedJWT.class);
+
+    @BeforeEach
+    void setup() {
+
+        when(jwt1.getExpiresAt()).thenReturn(Date.from(TOKEN_EXPIRE_AT));
+        when(jwt2.getExpiresAt()).thenReturn(Date.from(TOKEN_EXPIRE_AT));
+
+        mockedClock = mock(Clock.class);
+
+        var cognitoAuthenticator = mock(CognitoAuthenticator.class);
+        when(cognitoAuthenticator.fetchBearerToken())
+            .thenReturn(jwt1)
+            .thenReturn(jwt2);
+        cachedJwtProvider = new CachedJwtProvider(cognitoAuthenticator, mockedClock);
+    }
+
+    @Test
+    void shouldGetSameTokenOnSequentialCallsWhenTokenIsNotExpired() {
+        var dateBeforeTokenExpiration = TOKEN_EXPIRE_AT.minus(Duration.ofMinutes(10));
+        when(mockedClock.instant()).thenReturn(dateBeforeTokenExpiration);
+
+        var token1 = cachedJwtProvider.getValue();
+        var token2 = cachedJwtProvider.getValue();
+
+        assertEquals(token1, token2);
+    }
+
+    @Test
+    void shouldGetNewTokenWhenTokenHasExpired() {
+        var dateAfterTokenExpiration = TOKEN_EXPIRE_AT.plus(Duration.ofMinutes(10));
+        when(mockedClock.instant()).thenReturn(dateAfterTokenExpiration);
+
+        var token1 = cachedJwtProvider.getValue();
+        var token2 = cachedJwtProvider.getValue();
+
+        assertNotEquals(token1, token2);
+    }
+
+    @Test
+    void shouldGetNewTokenWhenTokenIsAboutToExpire() {
+        var dateBeforeTokenExpiration = TOKEN_EXPIRE_AT.minus(Duration.ofSeconds(2));
+        when(mockedClock.instant()).thenReturn(dateBeforeTokenExpiration);
+
+        var token1 = cachedJwtProvider.getValue();
+        var token2 = cachedJwtProvider.getValue();
+
+        assertNotEquals(token1, token2);
+    }
+}

--- a/auth/src/test/java/no/unit/nva/auth/CognitoAuthenticatorTest.java
+++ b/auth/src/test/java/no/unit/nva/auth/CognitoAuthenticatorTest.java
@@ -1,0 +1,113 @@
+package no.unit.nva.auth;
+
+import static com.amazonaws.auth.internal.SignerConstants.AUTHORIZATION;
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static no.unit.nva.auth.AuthorizedBackendClient.APPLICATION_X_WWW_FORM_URLENCODED;
+import static no.unit.nva.auth.CognitoAuthenticator.AUTHORIZATION_ERROR_MESSAGE;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.apache.http.protocol.HTTP.CONTENT_TYPE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.NoSuchElementException;
+import no.unit.nva.auth.utils.HttpRequestMetadataMatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CognitoAuthenticatorTest {
+
+    public static String TEST_TOKEN =
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2Njg1MTE4NTcsImV4cCI6MTcw"
+        + "MDA0Nzg1NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSI"
+        + "sIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjoiTWFuYWdlciIsInNjb3BlIjoiZXhhbX"
+        + "BsZS1zY29wZSJ9.ne8Jb4f2xao1zSJFZxIBRrh4WFNjkaBRV3-Ybp6fHZU";
+    public static String TEST_SCOPE = "example-scope";
+    final HttpClient httpClient = mock(HttpClient.class);
+    HttpResponse<String> okResponse = mock(HttpResponse.class);
+    HttpResponse<String> invalidResponse = mock(HttpResponse.class);
+    HttpResponse<String> errorResponse = mock(HttpResponse.class);
+    private CognitoCredentials credentials;
+    private CognitoAuthenticator cognitoAuthenticator;
+
+    @BeforeEach
+    public void setup() {
+        var authServer = "http://localhost";
+        var clientId = randomString();
+        var clientSecret = randomString();
+        credentials = new CognitoCredentials(() -> clientId, () -> clientSecret, URI.create(authServer));
+        cognitoAuthenticator = new CognitoAuthenticator(httpClient, credentials);
+
+        when(okResponse.statusCode()).thenReturn(HTTP_OK);
+        when(okResponse.body()).thenReturn("{\"access_token\": \"" + TEST_TOKEN + "\"}");
+
+        when(invalidResponse.statusCode()).thenReturn(HTTP_OK);
+        when(invalidResponse.body()).thenReturn("{}");
+
+        when(errorResponse.statusCode()).thenReturn(HTTP_FORBIDDEN);
+        when(errorResponse.body()).thenReturn("{}");
+    }
+
+    @Test
+    void shouldReturnJwtTokenFromHttpRequestToCognito() throws IOException, InterruptedException {
+        when(httpClient.<String>send(any(), any())).thenReturn(okResponse);
+
+        var jwt = cognitoAuthenticator.fetchBearerToken();
+        assertThat(jwt.getToken(), is(TEST_TOKEN));
+    }
+
+    @Test
+    void shouldReturnDecodedJwtWithClaims() throws IOException, InterruptedException {
+        when(httpClient.<String>send(any(), any())).thenReturn(okResponse);
+
+        var jwt = cognitoAuthenticator.fetchBearerToken();
+        assertThat(jwt.getClaim("scope").asString(), is(TEST_SCOPE));
+    }
+
+    @Test
+    void shouldReturnDecodedJwtWhenSendingBasicAuthentication() throws IOException, InterruptedException {
+        var uri = URI.create(credentials.getCognitoOAuthServerUri().toString() + "/oauth2/token");
+        var usernamePassword = credentials.getCognitoAppClientId() + ":" + credentials.getCognitoAppClientSecret();
+        var encodedAuth = Base64.getEncoder().encodeToString(usernamePassword.getBytes(StandardCharsets.UTF_8));
+
+        var expectedRequest = HttpRequest.newBuilder()
+                                  .uri(uri)
+                                  .setHeader(AUTHORIZATION, "Basic " + encodedAuth)
+                                  .setHeader(CONTENT_TYPE, APPLICATION_X_WWW_FORM_URLENCODED)
+                                  .POST(BodyPublishers.noBody())
+                                  .build();
+
+        when(httpClient.<String>send(argThat(new HttpRequestMetadataMatcher(expectedRequest)), any()))
+            .thenReturn(okResponse);
+
+        var jwt = cognitoAuthenticator.fetchBearerToken();
+        assertNotNull(jwt);
+    }
+
+    @Test
+    void shouldThrowWhenResponseIsNotStructuredLikeAToken() throws IOException, InterruptedException {
+        when(httpClient.<String>send(any(), any())).thenReturn(invalidResponse);
+        assertThrows(NoSuchElementException.class, () -> cognitoAuthenticator.fetchBearerToken());
+    }
+
+    @Test
+    void shouldThrowWhenResponseIsNot200Ok() throws IOException, InterruptedException {
+        when(httpClient.<String>send(any(), any())).thenReturn(errorResponse);
+        var exception = assertThrows(RuntimeException.class, () -> cognitoAuthenticator.fetchBearerToken());
+        assertEquals(AUTHORIZATION_ERROR_MESSAGE, exception.getMessage());
+    }
+}

--- a/auth/src/test/java/no/unit/nva/auth/utils/HttpRequestMetadataMatcher.java
+++ b/auth/src/test/java/no/unit/nva/auth/utils/HttpRequestMetadataMatcher.java
@@ -1,0 +1,24 @@
+package no.unit.nva.auth.utils;
+
+import java.net.http.HttpRequest;
+import org.mockito.ArgumentMatcher;
+
+/**
+ * A ArgumentMatcher that will match whenever 2 HttpRequests have the same URI, Headers and Method. Does not compare the
+ * body
+ */
+public class HttpRequestMetadataMatcher implements ArgumentMatcher<HttpRequest> {
+
+    private HttpRequest sourceRequest;
+
+    public HttpRequestMetadataMatcher(HttpRequest sourceRequest) {
+        this.sourceRequest = sourceRequest;
+    }
+
+    @Override
+    public boolean matches(HttpRequest request) {
+        return request.method().equals(sourceRequest.method())
+               && request.uri().equals(sourceRequest.uri())
+               && request.headers().equals(sourceRequest.headers());
+    }
+}

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.30.1'
+version = '1.30.2'
 
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ slf4j = { strictly = '1.8.0-beta4' }
 apiGuardian = { strictly = '1.1.2' }
 wiremock = { strictly = '2.35.0' }
 datafaker = { strictly = '1.9.0' }
+com-auth0-jwt = { strictly = '3.18.3' }
 
 [libraries]
 zalando = { group = 'org.zalando', name = 'problem', version.ref = 'zalandoProblem' }
@@ -29,6 +30,7 @@ zalando = { group = 'org.zalando', name = 'problem', version.ref = 'zalandoProbl
 guava = { group = 'com.google.guava', name = 'guava', version.ref = 'guava' }
 
 aws-sdk-dynamo = { group = 'com.amazonaws', name = 'aws-java-sdk-dynamodb', version.ref = 'awsSdk' }
+aws-java-sdk-core = { group = 'com.amazonaws', name = 'aws-java-sdk-core', version.ref = 'awsSdk' }
 aws-lambda-events = { group = 'com.amazonaws', name = 'aws-lambda-java-events', version.ref = 'awsLambdaEvents' }
 aws-lambda-core = { group = 'com.amazonaws', name = 'aws-lambda-java-core', version.ref = 'awsLambdaCore' }
 
@@ -83,6 +85,8 @@ hamcrest-optional = { group = 'com.github.npathai', name = 'hamcrest-optional', 
 
 apiguardian = { group = 'org.apiguardian', name = 'apiguardian-api', version.ref = 'apiGuardian' }
 wiremock = { group = 'com.github.tomakehurst', name = 'wiremock-jre8', version.ref = 'wiremock' }
+
+com-auth0-jwt = { group = 'com.auth0', name =  'java-jwt', version.ref = 'com-auth0-jwt' }
 
 [bundles]
 testing = ['mockito-core', 'hamcrest', 'hamcrest-core', 'junit-jupiter', 'junit-jupiter-api',


### PR DESCRIPTION
Copied CachedJwtProvider and CognitoAuthenticator from search-commons (search-api)

Needed in nvi project for authenticated open search client.