### PR TITLE
adding uriRetriever to commons

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
     implementation project(":core")
     implementation project(":json")
+    implementation project(":secrets")
 
     implementation libs.guava
     implementation libs.bundles.logging
@@ -18,6 +19,7 @@ dependencies {
     implementation libs.com.auth0.jwt
 
     implementation libs.aws.java.sdk.core
+    implementation libs.aws.sdk2.secrets
 
     testImplementation libs.bundles.testing
     testImplementation project(":logutils")

--- a/auth/src/main/java/no/unit/nva/auth/uriretriever/AuthorizedBackendUriRetriever.java
+++ b/auth/src/main/java/no/unit/nva/auth/uriretriever/AuthorizedBackendUriRetriever.java
@@ -1,0 +1,93 @@
+package no.unit.nva.auth.uriretriever;
+
+import static nva.commons.core.attempt.Try.attempt;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import javax.net.ssl.HttpsURLConnection;
+import no.unit.nva.auth.AuthorizedBackendClient;
+import no.unit.nva.auth.CognitoCredentials;
+import nva.commons.core.JacocoGenerated;
+import nva.commons.core.paths.UriWrapper;
+import nva.commons.secrets.SecretsReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+
+@JacocoGenerated
+public class AuthorizedBackendUriRetriever implements RawContentRetriever {
+
+    public static final String FAILED_TO_RETRIEVE_URI = "Failed to retrieve uri {}";
+    public static final String API_RESPONDED_WITH_ERROR_CODE = "Api responded with: ";
+    public static final String ACCEPT = "Accept";
+    private static final Logger logger = LoggerFactory.getLogger(AuthorizedBackendUriRetriever.class);
+    private final HttpClient httpClient;
+    private final SecretsReader secretsReader;
+
+    private final String backendClientAuthUrl;
+
+    private final String backendClientSecretName;
+
+    public AuthorizedBackendUriRetriever(HttpClient httpClient,
+                                         SecretsManagerClient secretsManagerClient,
+                                         String backendClientAuthUrl,
+                                         String backendClientSecretName) {
+        this.httpClient = httpClient;
+        this.secretsReader = new SecretsReader(secretsManagerClient);
+        this.backendClientAuthUrl = backendClientAuthUrl;
+        this.backendClientSecretName = backendClientSecretName;
+    }
+
+    @JacocoGenerated
+    public AuthorizedBackendUriRetriever(String backendClientAuthUrl, String backendClientSecretName) {
+        this(HttpClient.newHttpClient(),
+             SecretsReader.defaultSecretsManagerClient(),
+             backendClientAuthUrl,
+             backendClientSecretName);
+    }
+
+    @Override
+    public Optional<String> getRawContent(URI uri, String mediaType) {
+        return attempt(this::getAuthorizedBackendClient)
+                   .map(authorizedBackendClient -> getHttpResponse(authorizedBackendClient, uri, mediaType))
+                   .map(this::getRawContentFromHttpResponse)
+                   .toOptional();
+    }
+
+    private URI getCognitoTokenUrl() {
+        return UriWrapper.fromHost(backendClientAuthUrl).getUri();
+    }
+
+    private String getRawContentFromHttpResponse(HttpResponse<String> response) {
+        if (response.statusCode() != HttpsURLConnection.HTTP_OK) {
+            logger.error(FAILED_TO_RETRIEVE_URI, response);
+            throw new RuntimeException(API_RESPONDED_WITH_ERROR_CODE + response.statusCode());
+        }
+        return response.body();
+    }
+
+    private CognitoCredentials fetchCredentials() {
+        var credentials
+            = secretsReader.fetchClassSecret(backendClientSecretName, BackendClientCredentials.class);
+        var uri = getCognitoTokenUrl();
+
+        return new CognitoCredentials(credentials::getId, credentials::getSecret, uri);
+    }
+
+    private AuthorizedBackendClient getAuthorizedBackendClient() {
+        return AuthorizedBackendClient.prepareWithCognitoCredentials(httpClient,
+                                                                     fetchCredentials());
+    }
+
+    private HttpResponse<String> getHttpResponse(AuthorizedBackendClient backendClient,
+                                                 URI customerId,
+                                                 String mediaType) throws IOException, InterruptedException {
+        var request = HttpRequest.newBuilder(customerId).headers(ACCEPT, mediaType).GET();
+        return backendClient.send(request, BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+}

--- a/auth/src/main/java/no/unit/nva/auth/uriretriever/BackendClientCredentials.java
+++ b/auth/src/main/java/no/unit/nva/auth/uriretriever/BackendClientCredentials.java
@@ -1,0 +1,39 @@
+package no.unit.nva.auth.uriretriever;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import nva.commons.core.JacocoGenerated;
+
+@JacocoGenerated
+public class BackendClientCredentials {
+
+    @JsonProperty("backendClientId")
+    public String id;
+
+    @JsonProperty("backendClientSecret")
+    public String secret;
+
+    @JacocoGenerated
+    public BackendClientCredentials() {
+    }
+
+    public BackendClientCredentials(String id, String secret) {
+        this.id = id;
+        this.secret = secret;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+               "\"backendClientId\": \"" + id + "\"" +
+               ", \"backendClientSecret\": \"" + secret + "\"" +
+               "}";
+    }
+}

--- a/auth/src/main/java/no/unit/nva/auth/uriretriever/RawContentRetriever.java
+++ b/auth/src/main/java/no/unit/nva/auth/uriretriever/RawContentRetriever.java
@@ -1,0 +1,9 @@
+package no.unit.nva.auth.uriretriever;
+
+import java.net.URI;
+import java.util.Optional;
+
+public interface RawContentRetriever {
+
+    Optional<String> getRawContent(URI uri, String mediaType);
+}

--- a/auth/src/main/java/no/unit/nva/auth/uriretriever/UriRetriever.java
+++ b/auth/src/main/java/no/unit/nva/auth/uriretriever/UriRetriever.java
@@ -1,0 +1,46 @@
+package no.unit.nva.auth.uriretriever;
+
+import static nva.commons.core.attempt.Try.attempt;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import nva.commons.core.JacocoGenerated;
+
+@JacocoGenerated
+public class UriRetriever implements RawContentRetriever {
+
+    public static final String ACCEPT = "Accept";
+    private final HttpClient httpClient;
+
+    public UriRetriever() {
+        this.httpClient = newHttpClient();
+    }
+
+    public UriRetriever(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public Optional<String> getRawContent(URI uri, String mediaType) {
+        return attempt(() -> httpClient.send(createHttpRequest(uri, mediaType),
+            BodyHandlers.ofString(StandardCharsets.UTF_8)))
+                   .map(HttpResponse::body)
+                   .toOptional();
+    }
+
+    private static HttpClient newHttpClient() {
+        return HttpClient.newHttpClient();
+    }
+
+    private HttpRequest createHttpRequest(URI uri, String mediaType) {
+        return HttpRequest.newBuilder()
+                   .uri(uri)
+                   .headers(ACCEPT, mediaType)
+                   .GET()
+                   .build();
+    }
+}

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.30.2'
+version = '1.30.3'
 
 
 


### PR DESCRIPTION
Adding UriRetriever as is to commons. There is no single test for UriRetriever in publication-api either. 
We need it for fetching affiliations when calculating nvi candidate. 