### PR TITLE
Firehose client throws exception on empty batch

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.30.5'
+version = '1.31.0'
 
 
 

--- a/core/src/test/java/nva/commons/core/parallel/ParallelMapperTest.java
+++ b/core/src/test/java/nva/commons/core/parallel/ParallelMapperTest.java
@@ -19,6 +19,7 @@ class ParallelMapperTest {
         List<Integer> inputs = sampleInputs(1_000);
 
         ParallelMapper<Integer, String> mapper = new ParallelMapper<>(inputs, this::integerToString).map();
+
         verifyParallelMapperTransformsInputObjects(mapper, inputs);
     }
 

--- a/nvatestutils/src/main/java/no/unit/nva/stubs/FakeFirehoseClient.java
+++ b/nvatestutils/src/main/java/no/unit/nva/stubs/FakeFirehoseClient.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import nva.commons.core.JacocoGenerated;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.firehose.FirehoseClient;
+import software.amazon.awssdk.services.firehose.model.FirehoseException;
 import software.amazon.awssdk.services.firehose.model.PutRecordBatchRequest;
 import software.amazon.awssdk.services.firehose.model.PutRecordBatchResponse;
 import software.amazon.awssdk.services.firehose.model.PutRecordRequest;
@@ -21,6 +23,9 @@ import software.amazon.awssdk.services.firehose.model.Record;
  */
 public class FakeFirehoseClient implements FirehoseClient {
 
+    public static final String EMPTY_RECORDS_MESSAGE_TEMPLATE =
+        "Value %s at 'records' failed to satisfy constraint: Member must have length greater "
+        + "than or equal to 1";
     private final List<Record> records = new ArrayList<>();
 
     @Override
@@ -31,8 +36,15 @@ public class FakeFirehoseClient implements FirehoseClient {
 
     @Override
     public PutRecordBatchResponse putRecordBatch(PutRecordBatchRequest putRecordBatchRequest) {
+        if(records.isEmpty()){
+            throw emptyBatchException();
+        }
         records.addAll(putRecordBatchRequest.records());
         return PutRecordBatchResponse.builder().build();
+    }
+
+    private AwsServiceException emptyBatchException() {
+        return FirehoseException.builder().message(String.format(EMPTY_RECORDS_MESSAGE_TEMPLATE, records)).build();
     }
 
     @JacocoGenerated

--- a/nvatestutils/src/main/java/no/unit/nva/stubs/FakeFirehoseClient.java
+++ b/nvatestutils/src/main/java/no/unit/nva/stubs/FakeFirehoseClient.java
@@ -36,15 +36,11 @@ public class FakeFirehoseClient implements FirehoseClient {
 
     @Override
     public PutRecordBatchResponse putRecordBatch(PutRecordBatchRequest putRecordBatchRequest) {
-        if(records.isEmpty()){
+        if (putRecordBatchRequest.records().isEmpty()) {
             throw emptyBatchException();
         }
         records.addAll(putRecordBatchRequest.records());
         return PutRecordBatchResponse.builder().build();
-    }
-
-    private AwsServiceException emptyBatchException() {
-        return FirehoseException.builder().message(String.format(EMPTY_RECORDS_MESSAGE_TEMPLATE, records)).build();
     }
 
     @JacocoGenerated
@@ -71,5 +67,9 @@ public class FakeFirehoseClient implements FirehoseClient {
 
     public <T> Stream<T> extractPushedContent(Function<String, T> parser) {
         return extractPushedContent().map(parser::apply);
+    }
+
+    private AwsServiceException emptyBatchException() {
+        return FirehoseException.builder().message(String.format(EMPTY_RECORDS_MESSAGE_TEMPLATE, records)).build();
     }
 }

--- a/nvatestutils/src/test/java/no/unit/nva/stubs/FakeFirehoseClientTest.java
+++ b/nvatestutils/src/test/java/no/unit/nva/stubs/FakeFirehoseClientTest.java
@@ -70,9 +70,17 @@ public class FakeFirehoseClientTest {
     }
 
     @Test
-    void shouldNotAcceptEmptyBatch(){
-        var request=  PutRecordBatchRequest.builder().records(Collections.emptyList()).build();
-        assertThrows(FirehoseException.class, ()->client.putRecordBatch(request));
+    void shouldNotAcceptEmptyBatch() {
+        var request = PutRecordBatchRequest.builder().records(Collections.emptyList()).build();
+        assertThrows(FirehoseException.class, () -> client.putRecordBatch(request));
+    }
+
+    private static Record toRecord(String content) {
+        return Record.builder().data(SdkBytes.fromString(content, StandardCharsets.UTF_8)).build();
+    }
+
+    private static Record randomRecord() {
+        return toRecord(randomString());
     }
 
     private List<Record> createRecords(List<JsonNode> expectedContent) {
@@ -87,14 +95,6 @@ public class FakeFirehoseClientTest {
         return Stream.of(randomJson(), randomJson())
                    .map(this::parseString)
                    .collect(Collectors.toList());
-    }
-
-    private static Record toRecord(String content) {
-        return Record.builder().data(SdkBytes.fromString(content, StandardCharsets.UTF_8)).build();
-    }
-
-    private static Record randomRecord() {
-        return toRecord(randomString());
     }
 
     private JsonNode parseString(String jsonString) {

--- a/nvatestutils/src/test/java/no/unit/nva/stubs/FakeFirehoseClientTest.java
+++ b/nvatestutils/src/test/java/no/unit/nva/stubs/FakeFirehoseClientTest.java
@@ -8,9 +8,11 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -19,6 +21,7 @@ import nva.commons.core.attempt.Try;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.firehose.model.FirehoseException;
 import software.amazon.awssdk.services.firehose.model.PutRecordBatchRequest;
 import software.amazon.awssdk.services.firehose.model.PutRecordRequest;
 import software.amazon.awssdk.services.firehose.model.Record;
@@ -64,6 +67,12 @@ public class FakeFirehoseClientTest {
         var actualContent = client.extractPushedContent(this::parseString).collect(Collectors.toList());
 
         assertThat(actualContent, contains(expectedContent.toArray(JsonNode[]::new)));
+    }
+
+    @Test
+    void shouldNotAcceptEmptyBatch(){
+        var request=  PutRecordBatchRequest.builder().records(Collections.emptyList()).build();
+        assertThrows(FirehoseException.class, ()->client.putRecordBatch(request));
     }
 
     private List<Record> createRecords(List<JsonNode> expectedContent) {


### PR DESCRIPTION
The real client throws an exception when pushing empty batch. We need to do the same.


Example from real call:
```
software.amazon.awssdk.services.firehose.model.FirehoseException: 1 validation error detected: Value '[]' at 'records' failed to satisfy constraint: Member must have length greater than or equal to 1 (Service: Firehose, Status Code: 400, Request ID: ......

	at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handleErrorResponse(CombinedResponseHandler.java:125)

```
