### PR TITLE
adding custom object to ApigGatewayException

### DIFF
--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
@@ -22,7 +22,6 @@ import java.util.function.Supplier;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.ApiGatewayUncheckedException;
 import nva.commons.apigateway.exceptions.GatewayResponseSerializingException;
-import nva.commons.apigateway.exceptions.GoneException;
 import nva.commons.apigateway.exceptions.RedirectException;
 import nva.commons.apigateway.exceptions.UnsupportedAcceptHeaderException;
 import nva.commons.core.Environment;
@@ -248,10 +247,14 @@ public abstract class ApiGatewayHandler<I, O> extends RestRequestHandler<I, O> {
                    .withTitle(status.getReasonPhrase())
                    .withDetail(errorMessage)
                    .with(REQUEST_ID, requestId)
-                   .with(RESOURCE, exception instanceof ApiGatewayException apiGatewayException
-                                         ? apiGatewayException.getInstance()
-                                         : null)
+                   .with(RESOURCE, getResource(exception))
                    .build();
+    }
+
+    private Object getResource(Exception exception) {
+        return exception instanceof ApiGatewayException apiGatewayException
+                   ? Optional.ofNullable(apiGatewayException.getInstance()).map(Object::toString).orElse(null)
+                   : null;
     }
 
     /**

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
@@ -40,6 +40,7 @@ public abstract class ApiGatewayHandler<I, O> extends RestRequestHandler<I, O> {
     public static final String DEFAULT_ERROR_MESSAGE = "Unknown error in handler";
     public static final String REQUEST_ID = "requestId";
     public static final Void EMPTY_BODY = null;
+    public static final String RESOURCE = "resource";
 
     private final ObjectMapper objectMapper;
 
@@ -241,22 +242,15 @@ public abstract class ApiGatewayHandler<I, O> extends RestRequestHandler<I, O> {
     }
 
     private ThrowableProblem createProblemDescription(Exception exception, Integer statusCode, String requestId) {
-        if (exception instanceof GoneException goneException) {
-            String errorMessage = Optional.ofNullable(exception.getMessage()).orElse(defaultErrorMessage());
-            Status status = Status.valueOf(statusCode);
-            return Problem.builder().withStatus(status)
-                       .withTitle(status.getReasonPhrase())
-                       .withDetail(errorMessage)
-                       .with(REQUEST_ID, requestId)
-                       .with("resource", goneException.getInstance().toString())
-                       .build();
-        }
         String errorMessage = Optional.ofNullable(exception.getMessage()).orElse(defaultErrorMessage());
         Status status = Status.valueOf(statusCode);
         return Problem.builder().withStatus(status)
                    .withTitle(status.getReasonPhrase())
                    .withDetail(errorMessage)
                    .with(REQUEST_ID, requestId)
+                   .with(RESOURCE, exception instanceof ApiGatewayException apiGatewayException
+                                         ? apiGatewayException.getInstance()
+                                         : null)
                    .build();
     }
 

--- a/apigateway/src/main/java/nva/commons/apigateway/exceptions/ApiGatewayException.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/exceptions/ApiGatewayException.java
@@ -6,6 +6,7 @@ public abstract class ApiGatewayException extends Exception {
 
     public static final String MISSING_STATUS_CODE = "Status code cannot be null for exception:";
     private Integer runtimeStatusCode;
+    private Object instance;
 
     public ApiGatewayException(String message) {
         super(message);
@@ -22,6 +23,15 @@ public abstract class ApiGatewayException extends Exception {
 
     public ApiGatewayException(Exception exception, String message) {
         super(message, exception);
+    }
+
+    public ApiGatewayException(String message, Object instance) {
+        super(message);
+        this.instance = instance;
+    }
+
+    public Object getInstance() {
+        return instance;
     }
 
     protected abstract Integer statusCode();

--- a/apigateway/src/main/java/nva/commons/apigateway/exceptions/GoneException.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/exceptions/GoneException.java
@@ -15,6 +15,7 @@ public class GoneException extends ApiGatewayException {
     public GoneException(Exception exception, String message) {
         super(exception, message);
     }
+
     public GoneException(String message, Object tombstone) {
         super(message, tombstone);
     }

--- a/apigateway/src/main/java/nva/commons/apigateway/exceptions/GoneException.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/exceptions/GoneException.java
@@ -15,6 +15,9 @@ public class GoneException extends ApiGatewayException {
     public GoneException(Exception exception, String message) {
         super(exception, message);
     }
+    public GoneException(String message, Object tombstone) {
+        super(message, tombstone);
+    }
 
     @Override
     protected Integer statusCode() {

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
@@ -79,11 +79,8 @@ class ApiGatewayHandlerTest {
     private Handler handler;
 
     public static Stream<String> mediaTypeProvider() {
-        return Stream.of(
-            MediaTypes.APPLICATION_JSON_LD.toString(),
-            MediaTypes.APPLICATION_DATACITE_XML.toString(),
-            MediaTypes.SCHEMA_ORG.toString()
-        );
+        return Stream.of(MediaTypes.APPLICATION_JSON_LD.toString(), MediaTypes.APPLICATION_DATACITE_XML.toString(),
+                         MediaTypes.SCHEMA_ORG.toString());
     }
 
     @BeforeEach
@@ -117,19 +114,16 @@ class ApiGatewayHandlerTest {
 
         Map<String, String> headers = handler.getHeaders();
         JsonNode expectedHeaders = createHeaders();
-        expectedHeaders.fieldNames().forEachRemaining(expectedHeader ->
-                                                          assertThat(headers.get(expectedHeader), is(equalTo(
-                                                              expectedHeaders.get(expectedHeader).textValue()))));
+        expectedHeaders.fieldNames()
+            .forEachRemaining(expectedHeader -> assertThat(headers.get(expectedHeader), is(equalTo(
+                expectedHeaders.get(expectedHeader).textValue()))));
     }
 
     // TODO: Should return 415 when the Content-type header of request is unsupported (i.e., the one
     //  describing the content of the body of a post request)
     // TODO: Should return 406 when Accept header contains unsupported media type
     @ParameterizedTest(name = "handleRequest should return Unsupported media-type when input is {0}")
-    @ValueSource(strings = {
-        "application/xml",
-        "text/plain; charset=UTF-8"
-    })
+    @ValueSource(strings = {"application/xml", "text/plain; charset=UTF-8"})
     public void handleRequestShouldReturnUnsupportedMediaTypeOnUnsupportedAcceptHeader(String mediaType)
         throws IOException {
         InputStream input = requestWithAcceptHeader(mediaType);
@@ -142,12 +136,9 @@ class ApiGatewayHandlerTest {
     }
 
     @ParameterizedTest(name = "handleRequest should return OK when input is {0}")
-    @ValueSource(strings = {
-        "*/*",
-        "application/json",
-        "application/json; charset=UTF-8",
-        "text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8",
-        "*; q=.2" // java.net.HttpURLConnection uses this Accept header
+    @ValueSource(strings = {"*/*", "application/json", "application/json; charset=UTF-8",
+        "text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8", "*; q=.2"
+        // java.net.HttpURLConnection uses this Accept header
     })
     public void handleRequestShouldReturnOkOnSupportedAcceptHeader(String mediaType) throws IOException {
         InputStream input = requestWithAcceptHeader(mediaType);
@@ -158,8 +149,7 @@ class ApiGatewayHandlerTest {
     }
 
     @Test
-    public void handleRequestReturnsContentTypeJsonOnAcceptWildcard()
-        throws IOException {
+    public void handleRequestReturnsContentTypeJsonOnAcceptWildcard() throws IOException {
         Handler handler = handlerThatOverridesListSupportedMediaTypes();
 
         InputStream input = requestWithAcceptHeader(MediaType.ANY_TYPE.toString());
@@ -168,20 +158,6 @@ class ApiGatewayHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(response.getHeaders().get(CONTENT_TYPE), is(equalTo(MediaType.JSON_UTF_8.toString())));
-    }
-
-    @ParameterizedTest(name = "Should return supported type {0} when it is requested")
-    @MethodSource("mediaTypeProvider")
-    void shouldReturnContentTypeMatchingSupportedMediaTypeWhenSupportedMediaTypeIsRequested(String mediaType)
-        throws IOException {
-        Handler handler = handlerThatOverridesListSupportedMediaTypes();
-
-        InputStream input = requestWithAcceptHeader(mediaType);
-
-        GatewayResponse<String> response = getStringResponse(input, handler);
-
-        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-        assertThat(response.getHeaders().get(CONTENT_TYPE), is(equalTo(mediaType)));
     }
 
     @Test
@@ -289,8 +265,7 @@ class ApiGatewayHandlerTest {
 
     @Test
     @DisplayName("Failure message contains exception message and status code when an Exception is thrown")
-    public void failureMessageContainsExceptionMessageAndStatusCodeWhenAnExceptionIsThrown()
-        throws IOException {
+    public void failureMessageContainsExceptionMessageAndStatusCodeWhenAnExceptionIsThrown() throws IOException {
         Handler handler = handlerThatThrowsExceptions();
 
         GatewayResponse<Problem> responseParsing = getProblemResponse(requestWithHeadersAndPath(), handler);
@@ -305,8 +280,7 @@ class ApiGatewayHandlerTest {
 
     @Test
     @DisplayName("Failure message contains application/problem+json ContentType when an Exception is thrown")
-    public void failureMessageContainsApplicationProblemJsonContentTypeWhenExceptionIsThrown()
-        throws IOException {
+    public void failureMessageContainsApplicationProblemJsonContentTypeWhenExceptionIsThrown() throws IOException {
         Handler handler = handlerThatThrowsExceptions();
 
         GatewayResponse<Problem> responseParsing = getProblemResponse(requestWithHeadersAndPath(), handler);
@@ -374,6 +348,20 @@ class ApiGatewayHandlerTest {
         assertThat(problem.getDetail(), containsString(expectedMessage));
     }
 
+    @ParameterizedTest(name = "Should return supported type {0} when it is requested")
+    @MethodSource("mediaTypeProvider")
+    void shouldReturnContentTypeMatchingSupportedMediaTypeWhenSupportedMediaTypeIsRequested(String mediaType)
+        throws IOException {
+        Handler handler = handlerThatOverridesListSupportedMediaTypes();
+
+        InputStream input = requestWithAcceptHeader(mediaType);
+
+        GatewayResponse<String> response = getStringResponse(input, handler);
+
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+        assertThat(response.getHeaders().get(CONTENT_TYPE), is(equalTo(mediaType)));
+    }
+
     @Test
     void handlerSerializesBodyWithNonDefaultSerializationWhenDefaultSerializerIsOverridden() throws IOException {
         ObjectMapper spiedMapper = spy(defaultRestObjectMapper);
@@ -435,9 +423,8 @@ class ApiGatewayHandlerTest {
     }
 
     private String getUnsupportedMediaTypeErrorMessage(String mediaType) {
-        return UnsupportedAcceptHeaderException.createMessage(
-            List.of(MediaType.parse(mediaType)),
-            handler.listSupportedMediaTypes());
+        return UnsupportedAcceptHeaderException.createMessage(List.of(MediaType.parse(mediaType)),
+                                                              handler.listSupportedMediaTypes());
     }
 
     private <T> GatewayResponse<T> getResponse(Class<T> type, InputStream input, Handler handler) throws IOException {
@@ -468,9 +455,7 @@ class ApiGatewayHandlerTest {
         requestBody.setField1("Some value");
         requestBody.setField2(null);
 
-        return new HandlerRequestBuilder<RequestBody>(defaultRestObjectMapper)
-                   .withBody(requestBody)
-                   .build();
+        return new HandlerRequestBuilder<RequestBody>(defaultRestObjectMapper).withBody(requestBody).build();
     }
 
     private Problem getProblemFromFailureResponse(ByteArrayOutputStream outputStream) throws JsonProcessingException {
@@ -641,8 +626,9 @@ class ApiGatewayHandlerTest {
     }
 
     private record CustomObject(String firstValue, String secondValue) implements JsonSerializable {
+
         public String toString() {
-        return this.toJsonString();
+            return this.toJsonString();
         }
     }
 }

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
@@ -273,6 +274,16 @@ class ApiGatewayHandlerTest {
         var problem = getProblemFromFailureResponse(outputStream);
 
         assertThat(problem.getParameters().get("resource"), is(equalTo(customProblemObject.toJsonString())));
+    }
+
+    @Test
+    public void problemShouldNotContainCustomResourceWhenResourceIsNull() throws IOException {
+        var handler = handlerThatThrowsGoneExceptionsWithCustomObject(null);
+        var outputStream = outputStream();
+        handler.handleRequest(requestWithHeaders(), outputStream, context);
+        var problem = getProblemFromFailureResponse(outputStream);
+
+        assertThat(problem.getParameters().get("resource"), is(nullValue()));
     }
 
     @Test

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
@@ -273,7 +273,8 @@ class ApiGatewayHandlerTest {
         handler.handleRequest(requestWithHeaders(), outputStream, context);
         var problem = getProblemFromFailureResponse(outputStream);
 
-        assertThat(problem.getParameters().get("resource"), is(equalTo(customProblemObject.toJsonString())));
+        var resource = problem.getParameters().get("resource");
+        assertThat(resource, is(equalTo(customProblemObject.toJsonString())));
     }
 
     @Test

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.36.0'
+version = '1.36.1'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility


### PR DESCRIPTION
This makes it possible to return problem+json containing some object, not only error detail. 
This will be used to return tombstone to frontend:

```
{
      statusCode: ...
      detail: ...
      resource: {
              .....
              .....
              .....
      }
}
```