### PR TITLE
Add user agent

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.37.4'
+version = '1.37.5'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility

--- a/core/src/main/java/nva/commons/core/useragent/InvalidUserAgentException.java
+++ b/core/src/main/java/nva/commons/core/useragent/InvalidUserAgentException.java
@@ -1,0 +1,8 @@
+package nva.commons.core.useragent;
+
+public class InvalidUserAgentException extends RuntimeException {
+
+    public InvalidUserAgentException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/nva/commons/core/useragent/UserAgent.java
+++ b/core/src/main/java/nva/commons/core/useragent/UserAgent.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * When sending HTTP requests, applying a User-Agent header allows the recipient to know who is executing the request.
  */
-public class UserAgent {
+public final class UserAgent {
 
     /**
      * For convenience, we provide the header.
@@ -43,10 +43,10 @@ public class UserAgent {
         public static final String USER_AGENT_TEMPLATE = "%s-%s/%s (%s; mailto:%s)";
         public static final String NULL_VALUE_ERROR = "No value for user agent builder may be null";
         private String clientName;
-        private String version;
+        private String versionName;
         private URI uri;
-        private String email;
-        private String environment;
+        private String emailAddress;
+        private String environmentName;
 
         private UserAgentBuilder() {
             // NO-OP
@@ -57,7 +57,7 @@ public class UserAgent {
          * @param aClass The root caller class that initiates the call.
          * @return UserAgentBuilder
          */
-        public UserAgentBuilder clientName(Class<?> aClass) {
+        public UserAgentBuilder client(Class<?> aClass) {
             this.clientName = aClass.getSimpleName();
             return this;
         }
@@ -68,7 +68,7 @@ public class UserAgent {
          * @return UserAgentBuilder
          */
         public UserAgentBuilder version(String version) {
-            this.version = version;
+            this.versionName = version;
             return this;
         }
 
@@ -88,7 +88,7 @@ public class UserAgent {
          * @return UserAgentBuilder
          */
         public UserAgentBuilder email(String email) {
-            this.email = email;
+            this.emailAddress = email;
             return this;
         }
 
@@ -98,7 +98,7 @@ public class UserAgent {
          * @return UserAgentBuilder
          */
         public UserAgentBuilder environment(String environment) {
-            this.environment = environment;
+            this.environmentName = environment;
             return this;
         }
 
@@ -107,8 +107,13 @@ public class UserAgent {
          * @return UserAgent.
          */
         public UserAgent build() {
-            validate(uri, clientName, environment, version, uri, email);
-            var userAgentString = String.format(USER_AGENT_TEMPLATE, clientName, environment, version, uri, email);
+            validate(uri, clientName, environmentName, versionName, uri, emailAddress);
+            var userAgentString = String.format(USER_AGENT_TEMPLATE,
+                                                clientName,
+                                                environmentName,
+                                                versionName,
+                                                uri,
+                                                emailAddress);
             return new UserAgent(userAgentString);
         }
 

--- a/core/src/main/java/nva/commons/core/useragent/UserAgent.java
+++ b/core/src/main/java/nva/commons/core/useragent/UserAgent.java
@@ -1,0 +1,121 @@
+package nva.commons.core.useragent;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * When sending HTTP requests, applying a User-Agent header allows the recipient to know who is executing the request.
+ */
+public class UserAgent {
+
+    /**
+     * For convenience, we provide the header.
+     */
+    public static final String USER_AGENT = "User-Agent";
+    private final String userAgentString;
+
+    private UserAgent(String userAgentString) {
+        this.userAgentString = userAgentString;
+    }
+
+    /**
+     * Creates a new UserAgentBuilder.
+     * @return a UserAgentBuilder.
+     */
+    public static UserAgentBuilder newBuilder() {
+        return new UserAgentBuilder();
+    }
+
+    /**
+     * Creates the actual string value.
+     * @return The User-Agent string.
+     */
+    @Override
+    public String toString() {
+        return userAgentString;
+    }
+
+    /**
+     * Allows the building of a valid UserAgent string.
+     */
+    public static class UserAgentBuilder {
+        public static final String USER_AGENT_TEMPLATE = "%s-%s/%s (%s; mailto:%s)";
+        public static final String NULL_VALUE_ERROR = "No value for user agent builder may be null";
+        private String clientName;
+        private String version;
+        private URI uri;
+        private String email;
+        private String environment;
+
+        private UserAgentBuilder() {
+            // NO-OP
+        }
+
+        /**
+         * The class that is calling, typically the Handler class that initiates the call.
+         * @param aClass The root caller class that initiates the call.
+         * @return UserAgentBuilder
+         */
+        public UserAgentBuilder clientName(Class<?> aClass) {
+            this.clientName = aClass.getSimpleName();
+            return this;
+        }
+
+        /**
+         * The version of Handler class that initiates the call.
+         * @param version The version string.
+         * @return UserAgentBuilder
+         */
+        public UserAgentBuilder version(String version) {
+            this.version = version;
+            return this;
+        }
+
+        /**
+         * The repository for the code of the calling class.
+         * @param uri The URI of the repository.
+         * @return UserAgentBuilder
+         */
+        public UserAgentBuilder repository(URI uri) {
+            this.uri = uri;
+            return this;
+        }
+
+        /**
+         * The contact email (typically support@somewhere) that recipients can contact in case of an issue.
+         * @param email The root caller class that initiates the call.
+         * @return UserAgentBuilder
+         */
+        public UserAgentBuilder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        /**
+         * The environment that is calling, typically dev, test, sandbox, e2e or prod.
+         * @param environment The environment.
+         * @return UserAgentBuilder
+         */
+        public UserAgentBuilder environment(String environment) {
+            this.environment = environment;
+            return this;
+        }
+
+        /**
+         * Builds the UserAgent.
+         * @return UserAgent.
+         */
+        public UserAgent build() {
+            validate(uri, clientName, environment, version, uri, email);
+            var userAgentString = String.format(USER_AGENT_TEMPLATE, clientName, environment, version, uri, email);
+            return new UserAgent(userAgentString);
+        }
+
+        private void validate(Object... objects) {
+            if (Arrays.stream(objects).anyMatch(Objects::isNull)) {
+                throw new InvalidUserAgentException(NULL_VALUE_ERROR);
+            }
+        }
+    }
+}

--- a/core/src/test/java/nva/commons/core/useragent/UserAgentTest.java
+++ b/core/src/test/java/nva/commons/core/useragent/UserAgentTest.java
@@ -1,0 +1,35 @@
+package nva.commons.core.useragent;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+class UserAgentTest {
+
+    @Test
+    void shouldAllowCreationOfUserAgentString() {
+        var actual = UserAgent.newBuilder()
+                         .clientName(UserAgentTest.class)
+                         .environment("dev")
+                         .version("1.0")
+                         .repository(URI.create("https://example.org/someRepo"))
+                         .email("someone@example.org")
+                         .build();
+        var expected = "UserAgentTest-dev/1.0 (https://example.org/someRepo; mailto:someone@example.org)";
+        assertThat(actual.toString(), is(equalTo(expected)));
+    }
+
+    @Test
+    void shouldThrowWhenBuilderValuesAreNull() {
+        var builder = UserAgent.newBuilder();
+        assertThrows(InvalidUserAgentException.class, builder::build);
+    }
+
+    @Test
+    void shouldHaveConstantForUserAgentHeaderString() {
+        assertThat(UserAgent.USER_AGENT, is(equalTo("User-Agent")));
+    }
+}

--- a/core/src/test/java/nva/commons/core/useragent/UserAgentTest.java
+++ b/core/src/test/java/nva/commons/core/useragent/UserAgentTest.java
@@ -12,7 +12,7 @@ class UserAgentTest {
     @Test
     void shouldAllowCreationOfUserAgentString() {
         var actual = UserAgent.newBuilder()
-                         .clientName(UserAgentTest.class)
+                         .client(UserAgentTest.class)
                          .environment("dev")
                          .version("1.0")
                          .repository(URI.create("https://example.org/someRepo"))


### PR DESCRIPTION
- I added this to core as HTTP requests are "core" to what we do, but I can buy that "net" is a better placement
- It adds a way of consistently specifying who is calling when we call that allows recipients to say "hey, you're doing this…"
- It builds a User-Agent string that allows us to know what, and where we are calling
- Follows https://datatracker.ietf.org/doc/html/rfc7231#page-46
- Example usage:

```
        var userAgent = UserAgent.newBuilder()
                         .client(UserAgentTest.class)
                         .environment("dev")
                         .version("1.0")
                         .repository(URI.create("https://example.org/someRepo"))
                         .email("someone@example.org")
                         .build();

        HttpRequest.newBuilder()
            .header(UserAgent.USER_AGENT, userAgent.toString());
 ```