### PR TITLE
ApigatewayHandler, Redirect response cors header

### DIFF
--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
@@ -203,7 +203,8 @@ public abstract class ApiGatewayHandler<I, O> extends RestRequestHandler<I, O> {
 
     private GatewayResponse<Void> createRedirectResponse(RedirectException exception)
         throws GatewayResponseSerializingException {
-        var responseHeaders = Map.of(HttpHeaders.LOCATION, exception.getLocation().toString());
+        var responseHeaders = Map.of(HttpHeaders.LOCATION, exception.getLocation().toString(),
+                                     ACCESS_CONTROL_ALLOW_ORIGIN, allowedOrigin);
         return new GatewayResponse<>(EMPTY_BODY, responseHeaders, exception.getStatusCode(), isBase64Encoded,
                                      objectMapper);
     }

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
@@ -5,6 +5,8 @@ import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static no.unit.nva.testutils.TestHeaders.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static no.unit.nva.testutils.TestHeaders.WILDCARD;
 import static nva.commons.apigateway.ApiGatewayHandler.REQUEST_ID;
 import static nva.commons.apigateway.MediaTypes.APPLICATION_PROBLEM_JSON;
 import static nva.commons.apigateway.RestConfig.defaultRestObjectMapper;
@@ -391,6 +393,7 @@ class ApiGatewayHandlerTest {
         var response = getResponse(Void.class, request, handler);
         assertThat(response.getStatusCode(), is(equalTo(expectedRedirectStatusCode)));
         assertThat(response.getHeaders(), hasEntry(HttpHeaders.LOCATION, expectedRedirectLocation.toString()));
+        assertThat(response.getHeaders(), hasEntry(ACCESS_CONTROL_ALLOW_ORIGIN, WILDCARD));
     }
 
     @Test

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.39.1'
+version = '1.39.2'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility


### PR DESCRIPTION
Set header `Access-Control-Allow-Origin` to environment variable `ALLOWED_ORIGIN` in ApigatewayHandler for redirect responses.