### PR TITLE
ApiS3PresignerGatewayHandler

### DIFF
--- a/apigateway/src/main/java/nva/commons/apigateway/ApiS3GatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiS3GatewayHandler.java
@@ -2,36 +2,26 @@ package nva.commons.apigateway;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.net.HttpURLConnection;
 import java.time.Duration;
-import java.util.Map;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
-import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
-public abstract class ApiS3GatewayHandler<I> extends ApiGatewayHandler<I, Void> {
+public abstract class ApiS3GatewayHandler<I> extends ApiS3PresignerGatewayHandler<I> {
 
-    public static final String AWS_REGION = new Environment().readEnv("AWS_REGION");
     public static final String BUCKET_NAME = new Environment().readEnv("LARGE_API_RESPONSES_BUCKET");
-    public static final String LOCATION = "Location";
     public static final Duration SIGN_DURATION = Duration.ofMinutes(60);
     private final S3Client s3client;
-    private final S3Presigner s3presigner;
 
     public ApiS3GatewayHandler(Class<I> iclass, S3Client s3client, S3Presigner s3Presigner) {
-        super(iclass);
+        super(iclass, s3Presigner);
         this.s3client = s3client;
-        this.s3presigner = s3Presigner;
     }
 
     @JacocoGenerated
@@ -40,65 +30,9 @@ public abstract class ApiS3GatewayHandler<I> extends ApiGatewayHandler<I, Void> 
                                S3Presigner s3Presigner,
                                Environment environment,
                                ObjectMapper objectMapper) {
-        super(iclass, environment, objectMapper);
+        super(iclass, s3Presigner, environment, objectMapper);
         this.s3client = s3client;
-        this.s3presigner = s3Presigner;
     }
-
-    @Override
-    @JacocoGenerated
-    protected Integer getSuccessStatusCode(I input, Void output) {
-        return HttpURLConnection.HTTP_MOVED_TEMP;
-    }
-
-    @Override
-    protected Void processInput(I input, RequestInfo requestInfo, Context context) throws BadRequestException {
-        var data = processS3Input(input, requestInfo, context);
-        var filename = context.getAwsRequestId();
-
-        writeDataToS3(filename, data);
-
-        var presign = presignS3Object(filename);
-
-        setLocationHeader(presign.url().toString());
-        return null;
-    }
-
-    private PresignedGetObjectRequest presignS3Object(String filename) {
-        var presignRequest = createPresignRequest(filename);
-        var presign = s3presigner.presignGetObject(presignRequest);
-        return presign;
-    }
-
-    private void writeDataToS3(String filename, String data) {
-        var request = PutObjectRequest.builder()
-                          .bucket(BUCKET_NAME)
-                          .contentType(getContentType())
-                          .key(filename)
-                          .build();
-        var requestBody = RequestBody.fromString(data);
-        this.s3client.putObject(request, requestBody);
-    }
-
-    private void setLocationHeader(String uri) {
-        addAdditionalHeaders(() -> Map.of(LOCATION, uri));
-    }
-
-    private static GetObjectPresignRequest createPresignRequest(String filename) {
-        return GetObjectPresignRequest.builder()
-                   .signatureDuration(SIGN_DURATION)
-                   .getObjectRequest(
-                       GetObjectRequest.builder()
-                           .bucket(BUCKET_NAME)
-                           .key(filename)
-                           .build()
-                   )
-                   .build();
-    }
-
-    protected abstract String processS3Input(I input, RequestInfo requestInfo, Context context) throws BadRequestException;
-
-    protected abstract String getContentType();
 
     @JacocoGenerated
     public static S3Client defaultS3Client() {
@@ -108,12 +42,36 @@ public abstract class ApiS3GatewayHandler<I> extends ApiGatewayHandler<I, Void> 
                    .build();
     }
 
-    @JacocoGenerated
-    public static S3Presigner defaultS3Presigner() {
-        return S3Presigner.builder()
-                   .region(Region.of(AWS_REGION))
-                   .credentialsProvider(DefaultCredentialsProvider.create())
-                   .build();
+    @Override
+    protected void generateAndWriteDataToS3(String filename, I input, RequestInfo requestInfo, Context context)
+        throws BadRequestException {
+        var data = processS3Input(input, requestInfo, context);
+        writeDataToS3(filename, data);
+    }
+
+    @Override
+    protected String getBucketName() {
+        return BUCKET_NAME;
+    }
+
+    @Override
+    protected Duration getSignDuration() {
+        return SIGN_DURATION;
+    }
+
+    protected abstract String processS3Input(I input, RequestInfo requestInfo, Context context)
+        throws BadRequestException;
+
+    protected abstract String getContentType();
+
+    private void writeDataToS3(String filename, String data) {
+        var request = PutObjectRequest.builder()
+                          .bucket(BUCKET_NAME)
+                          .contentType(getContentType())
+                          .key(filename)
+                          .build();
+        var requestBody = RequestBody.fromString(data);
+        this.s3client.putObject(request, requestBody);
     }
 }
 

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
@@ -2,6 +2,7 @@ package nva.commons.apigateway;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
+import java.net.URL;
 import java.time.Duration;
 import java.util.Map;
 import nva.commons.apigateway.exceptions.BadRequestException;
@@ -25,9 +26,9 @@ public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<
     @Override
     protected Void processInput(I input, RequestInfo requestInfo, Context context) throws BadRequestException {
         var filename = context.getAwsRequestId();
-        var presign = presignS3Object(filename);
-        generateAndWriteDataToS3(filename, input);
-        setLocationHeader(presign.url().toString());
+        var preSignedUrl = presignS3Object(filename).url();
+        generateAndWriteDataToS3(preSignedUrl, input);
+        setLocationHeader(preSignedUrl.toString());
         return null;
     }
 
@@ -37,7 +38,7 @@ public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<
         return HttpURLConnection.HTTP_MOVED_TEMP;
     }
 
-    protected abstract void generateAndWriteDataToS3(String filename, I input);
+    protected abstract void generateAndWriteDataToS3(URL preSignedUrl, I input);
 
     protected abstract String getBucketName();
 

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
@@ -1,0 +1,66 @@
+package nva.commons.apigateway;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import java.net.HttpURLConnection;
+import java.time.Duration;
+import java.util.Map;
+import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.core.JacocoGenerated;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<I, Void> {
+
+    public static final String LOCATION = "Location";
+    public static final Duration SIGN_DURATION = Duration.ofMinutes(60);
+    private final S3Presigner s3presigner;
+
+    public ApiS3PresignerGatewayHandler(Class<I> iclass, S3Presigner s3Presigner) {
+        super(iclass);
+        this.s3presigner = s3Presigner;
+    }
+
+    @Override
+    protected Void processInput(I input, RequestInfo requestInfo, Context context) throws BadRequestException {
+        var filename = context.getAwsRequestId();
+        var presign = presignS3Object(filename);
+        generateAndWriteDataToS3(filename, input);
+        setLocationHeader(presign.url().toString());
+        return null;
+    }
+
+    @Override
+    @JacocoGenerated
+    protected Integer getSuccessStatusCode(I input, Void output) {
+        return HttpURLConnection.HTTP_MOVED_TEMP;
+    }
+
+    protected abstract void generateAndWriteDataToS3(String filename, I input);
+
+    protected abstract String getBucketName();
+
+    private GetObjectPresignRequest createPresignRequest(String filename) {
+        return GetObjectPresignRequest.builder()
+                   .signatureDuration(SIGN_DURATION)
+                   .getObjectRequest(buildRequest(filename))
+                   .build();
+    }
+
+    private GetObjectRequest buildRequest(String filename) {
+        return GetObjectRequest.builder()
+                   .bucket(getBucketName())
+                   .key(filename)
+                   .build();
+    }
+
+    private void setLocationHeader(String uri) {
+        addAdditionalHeaders(() -> Map.of(LOCATION, uri));
+    }
+
+    private PresignedGetObjectRequest presignS3Object(String filename) {
+        var presignRequest = createPresignRequest(filename);
+        return s3presigner.presignGetObject(presignRequest);
+    }
+}

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
@@ -15,7 +15,6 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<I, Void> {
 
     public static final String LOCATION = "Location";
-    public static final Duration SIGN_DURATION = Duration.ofMinutes(60);
     private final S3Presigner s3presigner;
 
     public ApiS3PresignerGatewayHandler(Class<I> iclass, S3Presigner s3Presigner) {
@@ -42,9 +41,11 @@ public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<
 
     protected abstract String getBucketName();
 
+    protected abstract Duration getSignDuration();
+
     private GetObjectPresignRequest createPresignRequest(String filename) {
         return GetObjectPresignRequest.builder()
-                   .signatureDuration(SIGN_DURATION)
+                   .signatureDuration(getSignDuration())
                    .getObjectRequest(buildRequest(filename))
                    .build();
     }

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
@@ -1,12 +1,15 @@
 package nva.commons.apigateway;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.HttpURLConnection;
-import java.net.URL;
 import java.time.Duration;
 import java.util.Map;
 import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -14,6 +17,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 
 public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<I, Void> {
 
+    public static final String AWS_REGION = new Environment().readEnv("AWS_REGION");
     public static final String LOCATION = "Location";
     private final S3Presigner s3presigner;
 
@@ -22,12 +26,29 @@ public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<
         this.s3presigner = s3Presigner;
     }
 
+    @JacocoGenerated
+    public ApiS3PresignerGatewayHandler(Class<I> iclass,
+                                        S3Presigner s3Presigner,
+                                        Environment environment,
+                                        ObjectMapper objectMapper) {
+        super(iclass, environment, objectMapper);
+        this.s3presigner = s3Presigner;
+    }
+
+    @JacocoGenerated
+    public static S3Presigner defaultS3Presigner() {
+        return S3Presigner.builder()
+                   .region(Region.of(AWS_REGION))
+                   .credentialsProvider(DefaultCredentialsProvider.create())
+                   .build();
+    }
+
     @Override
     protected Void processInput(I input, RequestInfo requestInfo, Context context) throws BadRequestException {
         var filename = context.getAwsRequestId();
-        var preSignedUrl = presignS3Object(filename).url();
-        generateAndWriteDataToS3(preSignedUrl, input);
-        setLocationHeader(preSignedUrl.toString());
+        generateAndWriteDataToS3(filename, input, requestInfo, context);
+        var preSignedUrl = presignS3Object(filename);
+        setLocationHeader(preSignedUrl.url().toString());
         return null;
     }
 
@@ -37,32 +58,33 @@ public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<
         return HttpURLConnection.HTTP_MOVED_TEMP;
     }
 
-    protected abstract void generateAndWriteDataToS3(URL preSignedUrl, I input);
+    protected abstract void generateAndWriteDataToS3(String filename, I input, RequestInfo requestInfo, Context context)
+        throws BadRequestException;
 
     protected abstract String getBucketName();
 
     protected abstract Duration getSignDuration();
 
-    private GetObjectPresignRequest createPresignRequest(String filename) {
-        return GetObjectPresignRequest.builder()
-                   .signatureDuration(getSignDuration())
-                   .getObjectRequest(buildRequest(filename))
-                   .build();
+    protected void setLocationHeader(String uri) {
+        addAdditionalHeaders(() -> Map.of(LOCATION, uri));
     }
 
-    private GetObjectRequest buildRequest(String filename) {
+    protected PresignedGetObjectRequest presignS3Object(String filename) {
+        var presignRequest = createPresignRequest(filename);
+        return s3presigner.presignGetObject(presignRequest);
+    }
+
+    protected GetObjectRequest buildRequest(String filename) {
         return GetObjectRequest.builder()
                    .bucket(getBucketName())
                    .key(filename)
                    .build();
     }
 
-    private void setLocationHeader(String uri) {
-        addAdditionalHeaders(() -> Map.of(LOCATION, uri));
-    }
-
-    private PresignedGetObjectRequest presignS3Object(String filename) {
-        var presignRequest = createPresignRequest(filename);
-        return s3presigner.presignGetObject(presignRequest);
+    protected GetObjectPresignRequest createPresignRequest(String filename) {
+        return GetObjectPresignRequest.builder()
+                   .signatureDuration(getSignDuration())
+                   .getObjectRequest(buildRequest(filename))
+                   .build();
     }
 }

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiS3GatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiS3GatewayHandlerTest.java
@@ -14,9 +14,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import no.unit.nva.stubs.FakeContext;
 import no.unit.nva.stubs.FakeS3Client;
 import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.core.Environment;
 import nva.commons.core.ioutils.IoUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,16 +32,15 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 
 class ApiS3GatewayHandlerTest {
 
+    public static final String BUCKET_NAME = "large-bucket";
     private S3Client s3Client;
     private S3Presigner s3Presigner;
     private ByteArrayOutputStream output;
-    private InputStream input;
 
     @BeforeEach
     void init() {
         s3Client = new FakeS3Client();
         s3Presigner = mock(S3Presigner.class);
-        this.input = InputStream.nullInputStream();
         this.output = new ByteArrayOutputStream();
     }
 
@@ -57,7 +58,7 @@ class ApiS3GatewayHandlerTest {
         var response = GatewayResponse.fromOutputStream(output, Void.class);
 
         var getRequest = GetObjectRequest.builder()
-                             .bucket("large-bucket")
+                             .bucket(BUCKET_NAME)
                              .key(expectedFilename)
                              .build();
 
@@ -74,8 +75,9 @@ class ApiS3GatewayHandlerTest {
         return presignRequest;
     }
 
-    private ApiS3GatewayHandler createHandler(String data) {
+    private ApiS3GatewayHandler<Void>createHandler(String data) {
         return new ApiS3GatewayHandler<>(Void.class, s3Client, s3Presigner) {
+
             @Override
             public String processS3Input(Void input, RequestInfo requestInfo, Context context) throws BadRequestException {
                 return data;

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import no.unit.nva.stubs.FakeContext;
 import nva.commons.core.ioutils.IoUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,6 +68,11 @@ class ApiS3PresignerGatewayHandlerTest {
             @Override
             protected String getBucketName() {
                 return "someTestBucket";
+            }
+
+            @Override
+            protected Duration getSignDuration() {
+                return Duration.ofMinutes(60);
             }
         };
     }

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import com.amazonaws.services.lambda.runtime.Context;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,6 +15,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
 import no.unit.nva.stubs.FakeContext;
+import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.ioutils.IoUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,9 +64,10 @@ class ApiS3PresignerGatewayHandlerTest {
         return new ApiS3PresignerGatewayHandler<Void>(Void.class, s3Presigner) {
 
             @Override
-            protected void generateAndWriteDataToS3(URL preSignedUrl, Void input) {
-            }
+            protected void generateAndWriteDataToS3(String filename, Void input, RequestInfo requestInfo,
+                                                    Context context) throws BadRequestException {
 
+            }
             @Override
             protected String getBucketName() {
                 return "someTestBucket";

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
@@ -61,7 +61,7 @@ class ApiS3PresignerGatewayHandlerTest {
         return new ApiS3PresignerGatewayHandler<Void>(Void.class, s3Presigner) {
 
             @Override
-            protected void generateAndWriteDataToS3(String filename, Void input) {
+            protected void generateAndWriteDataToS3(URL preSignedUrl, Void input) {
             }
 
             @Override

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
@@ -1,0 +1,73 @@
+package nva.commons.apigateway;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import no.unit.nva.stubs.FakeContext;
+import nva.commons.core.ioutils.IoUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+class ApiS3PresignerGatewayHandlerTest {
+
+    private S3Presigner s3Presigner;
+    private ByteArrayOutputStream output;
+    private InputStream input;
+    private ApiS3PresignerGatewayHandler<Void> handler;
+
+    @BeforeEach
+    void init() {
+        s3Presigner = mock(S3Presigner.class);
+        input = IoUtils.stringToStream("{}");
+        output = new ByteArrayOutputStream();
+        handler = createHandler();
+    }
+
+    @Test
+    void shouldSetLocationHeader() throws IOException {
+        var context = new FakeContext();
+        var expectedFilename = context.getAwsRequestId();
+
+        var presignedGetObjectRequest = mockPresignResponse(expectedFilename);
+        when(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class))).thenReturn(presignedGetObjectRequest);
+
+        handler.handleRequest(input, output, context);
+        var response = GatewayResponse.fromOutputStream(output, Void.class);
+        assertThat(response.getHeaders().get("Location"), containsString(expectedFilename));
+        assertThat(response.getStatusCode(), is(equalTo(HttpStatusCode.MOVED_TEMPORARILY)));
+    }
+
+    private static PresignedGetObjectRequest mockPresignResponse(String filename) throws MalformedURLException {
+        var presignRequest = mock(PresignedGetObjectRequest.class);
+        var presignedUrl = "https://example.com/" + filename;
+        when(presignRequest.url()).thenReturn(new URL(presignedUrl));
+        return presignRequest;
+    }
+
+    private ApiS3PresignerGatewayHandler<Void> createHandler() {
+        return new ApiS3PresignerGatewayHandler<Void>(Void.class, s3Presigner) {
+
+            @Override
+            protected void generateAndWriteDataToS3(String filename, Void input) {
+            }
+
+            @Override
+            protected String getBucketName() {
+                return "someTestBucket";
+            }
+        };
+    }
+}

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.39.3'
+version = '1.39.4'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility


### PR DESCRIPTION
`ApiS3PresignerGatewayHandler`: To handle cases where generation of export data takes too long time (longer than api gateway timeout). Handler that generates and returns a pre-signed s3 url. Abstract method `generateAndWriteDataToS3` lets handler delegate creation of data to different handler.

Similar to `ApiS3GatewayHandler`, but in this handler data creation can be delegated.