### PR TITLE
RestRequestHandler, validateRequest

### DIFF
--- a/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.util.Map;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
-import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -45,9 +45,7 @@ public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<
     }
 
     @Override
-    protected Void processInput(I input, RequestInfo requestInfo, Context context)
-        throws BadRequestException, UnauthorizedException {
-        validateRequest(input, requestInfo, context);
+    protected Void processInput(I input, RequestInfo requestInfo, Context context) throws ApiGatewayException {
         var filename = context.getAwsRequestId();
         generateAndWriteDataToS3(filename, input, requestInfo, context);
         var preSignedUrl = presignS3Object(filename);
@@ -60,9 +58,6 @@ public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<
     protected Integer getSuccessStatusCode(I input, Void output) {
         return HttpURLConnection.HTTP_MOVED_TEMP;
     }
-
-    protected abstract void validateRequest(I input, RequestInfo requestInfo, Context context)
-        throws UnauthorizedException;
 
     protected abstract void generateAndWriteDataToS3(String filename, I input, RequestInfo requestInfo, Context context)
         throws BadRequestException;

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
@@ -6,6 +6,7 @@ import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.util.Map;
 import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -44,7 +45,9 @@ public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<
     }
 
     @Override
-    protected Void processInput(I input, RequestInfo requestInfo, Context context) throws BadRequestException {
+    protected Void processInput(I input, RequestInfo requestInfo, Context context)
+        throws BadRequestException, UnauthorizedException {
+        validateRequest(input, requestInfo, context);
         var filename = context.getAwsRequestId();
         generateAndWriteDataToS3(filename, input, requestInfo, context);
         var preSignedUrl = presignS3Object(filename);
@@ -57,6 +60,9 @@ public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<
     protected Integer getSuccessStatusCode(I input, Void output) {
         return HttpURLConnection.HTTP_MOVED_TEMP;
     }
+
+    protected abstract void validateRequest(I input, RequestInfo requestInfo, Context context)
+        throws UnauthorizedException;
 
     protected abstract void generateAndWriteDataToS3(String filename, I input, RequestInfo requestInfo, Context context)
         throws BadRequestException;

--- a/apigateway/src/main/java/nva/commons/apigateway/RestRequestHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/RestRequestHandler.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.GatewayResponseSerializingException;
+import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.apigateway.exceptions.UnsupportedAcceptHeaderException;
 import nva.commons.core.Environment;
 import nva.commons.core.attempt.Failure;
@@ -146,7 +147,7 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
 
             RequestInfo requestInfo = inputParser.getRequestInfo(inputString);
 
-            validateRequest(inputObject, requestInfo, context);
+            validateAccessRights(inputObject, requestInfo, context);
 
             O response = processInput(inputObject, requestInfo, context);
 
@@ -159,7 +160,8 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
     }
 
     @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
-    protected void validateRequest(I inputObject, RequestInfo requestInfo, Context context) throws ApiGatewayException{
+    protected void validateAccessRights(I inputObject, RequestInfo requestInfo, Context context) throws
+                                                                                                 UnauthorizedException {
         //Empty method to avoid breaking changes in existing implementations
     }
 

--- a/apigateway/src/main/java/nva/commons/apigateway/RestRequestHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/RestRequestHandler.java
@@ -146,6 +146,8 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
 
             RequestInfo requestInfo = inputParser.getRequestInfo(inputString);
 
+            validateRequest(inputObject, requestInfo, context);
+
             O response = processInput(inputObject, requestInfo, context);
 
             writeOutput(inputObject, response, requestInfo);
@@ -154,6 +156,11 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
         } catch (Exception e) {
             handleUnexpectedException(context, inputObject, e);
         }
+    }
+
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+    protected void validateRequest(I inputObject, RequestInfo requestInfo, Context context) throws ApiGatewayException{
+        //Empty method to avoid breaking changes in existing implementations
     }
 
     protected ApiGatewayException parsingExceptionToBadRequestException(Failure<I> fail) {

--- a/apigateway/src/main/java/nva/commons/apigateway/RestRequestHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/RestRequestHandler.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.GatewayResponseSerializingException;
-import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.apigateway.exceptions.UnsupportedAcceptHeaderException;
 import nva.commons.core.Environment;
 import nva.commons.core.attempt.Failure;
@@ -147,7 +146,7 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
 
             RequestInfo requestInfo = inputParser.getRequestInfo(inputString);
 
-            validateAccessRights(inputObject, requestInfo, context);
+            validateRequest(inputObject, requestInfo, context);
 
             O response = processInput(inputObject, requestInfo, context);
 
@@ -159,11 +158,17 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
         }
     }
 
-    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
-    protected void validateAccessRights(I inputObject, RequestInfo requestInfo, Context context) throws
-                                                                                                 UnauthorizedException {
-        //Empty method to avoid breaking changes in existing implementations
-    }
+    /**
+     * Implements input validation and access control.
+     * {@link RestRequestHandler#handleExpectedException} method.
+     *
+     * @param input       The input object to the method. Usually a deserialized json.
+     * @param requestInfo Request headers and path.
+     * @param context     the ApiGateway context.
+     * @throws ApiGatewayException all exceptions are caught by writeFailure and mapped to error codes through the
+     *                             method {@link RestRequestHandler#getFailureStatusCode}
+     */
+    protected abstract void validateRequest(I input, RequestInfo requestInfo, Context context) throws ApiGatewayException;
 
     protected ApiGatewayException parsingExceptionToBadRequestException(Failure<I> fail) {
         return new BadRequestException(fail.getException().getMessage(), fail.getException());

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
@@ -98,6 +98,12 @@ class ApiGatewayHandlerTest {
     public void apiGatewayHandlerHasAConstructorWithInputClassAsOnlyParameter() {
         RestRequestHandler<String, String> handler = new ApiGatewayHandler<>(String.class) {
             @Override
+            protected void validateRequest(String input, RequestInfo requestInfo, Context context)
+                throws ApiGatewayException {
+                //no-op
+            }
+
+            @Override
             protected String processInput(String input, RequestInfo requestInfo, Context context) {
                 return null;
             }

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayProxyHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayProxyHandlerTest.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import no.unit.nva.stubs.FakeContext;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.testutils.ProxyHandler;
 import nva.commons.apigateway.testutils.RequestBody;
 import nva.commons.core.ioutils.IoUtils;
@@ -41,7 +42,13 @@ class ApiGatewayProxyHandlerTest {
     @DisplayName("ApiGatewayProxyHandlerTest has a constructor with input class as only parameter")
     public void apiGatewayHandlerHasACostructorWithInputClassAsOnlyParameter() {
         RestRequestHandler<String, String> handler = new ApiGatewayProxyHandler<>(String.class) {
-    
+
+            @Override
+            protected void validateRequest(String input, RequestInfo requestInfo, Context context)
+                throws ApiGatewayException {
+                //no-op
+            }
+
             @Override
             protected ProxyResponse<String> processProxyInput(String input, RequestInfo requestInfo, Context context) {
                 return null;

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiS3GatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiS3GatewayHandlerTest.java
@@ -15,6 +15,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import no.unit.nva.stubs.FakeContext;
 import no.unit.nva.stubs.FakeS3Client;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.ioutils.IoUtils;
@@ -77,8 +78,8 @@ class ApiS3GatewayHandlerTest {
         return new ApiS3GatewayHandler<>(Void.class, s3Client, s3Presigner) {
 
             @Override
-            protected void validateAccessRights(Void input, RequestInfo requestInfo, Context context)
-                throws UnauthorizedException {
+            protected void validateRequest(Void input, RequestInfo requestInfo, Context context)
+                throws ApiGatewayException {
                 //no-op
             }
 

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiS3GatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiS3GatewayHandlerTest.java
@@ -11,14 +11,12 @@ import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.time.Duration;
 import no.unit.nva.stubs.FakeContext;
 import no.unit.nva.stubs.FakeS3Client;
 import nva.commons.apigateway.exceptions.BadRequestException;
-import nva.commons.core.Environment;
+import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.ioutils.IoUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,8 +73,14 @@ class ApiS3GatewayHandlerTest {
         return presignRequest;
     }
 
-    private ApiS3GatewayHandler<Void>createHandler(String data) {
+    private ApiS3GatewayHandler<Void> createHandler(String data) {
         return new ApiS3GatewayHandler<>(Void.class, s3Client, s3Presigner) {
+
+            @Override
+            protected void validateRequest(Void input, RequestInfo requestInfo, Context context)
+                throws UnauthorizedException {
+                //no-op
+            }
 
             @Override
             public String processS3Input(Void input, RequestInfo requestInfo, Context context) throws BadRequestException {
@@ -89,5 +93,4 @@ class ApiS3GatewayHandlerTest {
             }
         };
     }
-
 }

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiS3GatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiS3GatewayHandlerTest.java
@@ -77,7 +77,7 @@ class ApiS3GatewayHandlerTest {
         return new ApiS3GatewayHandler<>(Void.class, s3Client, s3Presigner) {
 
             @Override
-            protected void validateRequest(Void input, RequestInfo requestInfo, Context context)
+            protected void validateAccessRights(Void input, RequestInfo requestInfo, Context context)
                 throws UnauthorizedException {
                 //no-op
             }

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
@@ -65,7 +65,7 @@ class ApiS3PresignerGatewayHandlerTest {
         return new ApiS3PresignerGatewayHandler<>(Void.class, s3Presigner) {
 
             @Override
-            protected void validateRequest(Void input, RequestInfo requestInfo, Context context)
+            protected void validateAccessRights(Void input, RequestInfo requestInfo, Context context)
                 throws UnauthorizedException {
                 //no-op
             }

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
@@ -16,6 +16,7 @@ import java.net.URL;
 import java.time.Duration;
 import no.unit.nva.stubs.FakeContext;
 import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.ioutils.IoUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,13 +62,19 @@ class ApiS3PresignerGatewayHandlerTest {
     }
 
     private ApiS3PresignerGatewayHandler<Void> createHandler() {
-        return new ApiS3PresignerGatewayHandler<Void>(Void.class, s3Presigner) {
+        return new ApiS3PresignerGatewayHandler<>(Void.class, s3Presigner) {
+
+            @Override
+            protected void validateRequest(Void input, RequestInfo requestInfo, Context context)
+                throws UnauthorizedException {
+                //no-op
+            }
 
             @Override
             protected void generateAndWriteDataToS3(String filename, Void input, RequestInfo requestInfo,
                                                     Context context) throws BadRequestException {
-
             }
+
             @Override
             protected String getBucketName() {
                 return "someTestBucket";

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiS3PresignerGatewayHandlerTest.java
@@ -15,6 +15,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
 import no.unit.nva.stubs.FakeContext;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.ioutils.IoUtils;
@@ -65,8 +66,8 @@ class ApiS3PresignerGatewayHandlerTest {
         return new ApiS3PresignerGatewayHandler<>(Void.class, s3Presigner) {
 
             @Override
-            protected void validateAccessRights(Void input, RequestInfo requestInfo, Context context)
-                throws UnauthorizedException {
+            protected void validateRequest(Void input, RequestInfo requestInfo, Context context)
+                throws ApiGatewayException {
                 //no-op
             }
 

--- a/apigateway/src/test/java/nva/commons/apigateway/VoidTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/VoidTest.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.nio.file.Path;
 import no.unit.nva.stubs.FakeContext;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.ioutils.IoUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,6 +76,12 @@ public class VoidTest {
 
         public VoidHandler(Environment environment) {
             super(Void.class, environment);
+        }
+
+        @Override
+        protected void validateRequest(Void input, RequestInfo requestInfo, Context context)
+            throws ApiGatewayException {
+            //no-op
         }
 
         @Override

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/Base64Handler.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/Base64Handler.java
@@ -14,6 +14,12 @@ public class Base64Handler extends ApiGatewayHandler<Void,Void> {
     }
 
     @Override
+    protected void validateRequest(Void input, RequestInfo requestInfo, Context context)
+        throws ApiGatewayException {
+        //no-op
+    }
+
+    @Override
     protected Void processInput(Void input, RequestInfo requestInfo, Context context) throws ApiGatewayException {
         setIsBase64Encoded(true);
         return null;

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/Handler.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/Handler.java
@@ -33,6 +33,12 @@ public class Handler extends ApiGatewayHandler<RequestBody, RequestBody> {
     }
 
     @Override
+    protected void validateRequest(RequestBody input, RequestInfo requestInfo, Context context)
+        throws ApiGatewayException {
+        //no-op
+    }
+
+    @Override
     protected RequestBody processInput(RequestBody input, RequestInfo requestInfo, Context context)
         throws ApiGatewayException {
         this.headers = requestInfo.getHeaders();

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/ProxyHandler.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/ProxyHandler.java
@@ -44,6 +44,12 @@ public class ProxyHandler extends ApiGatewayProxyHandler<RequestBody, RequestBod
         return new ProxyResponse<>(HTTP_STATUS_CODE_TEST, this.body);
     }
 
+    @Override
+    protected void validateRequest(RequestBody input, RequestInfo requestInfo, Context context)
+        throws ApiGatewayException {
+        //no-op
+    }
+
     private Map<String, String> additionalHeaders(RequestBody input) {
         return Collections.singletonMap(HttpHeaders.WARNING, body.getField1());
     }

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/RawStringResponseHandler.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/RawStringResponseHandler.java
@@ -62,6 +62,12 @@ public class RawStringResponseHandler extends ApiGatewayHandler<RequestBody, Str
     }
 
     @Override
+    protected void validateRequest(RequestBody input, RequestInfo requestInfo, Context context)
+        throws ApiGatewayException {
+        //no-op
+    }
+
+    @Override
     protected Map<MediaType, ObjectMapper> getObjectMappers() {
         return Map.of(XML_UTF_8, new XmlMapper());
     }

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.39.5'
+version = '1.40.0'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.39.4'
+version = '1.39.5'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility


### PR DESCRIPTION
Initially needed to validate access rights in `ApiS3PresignerGatewayHandler`, but I think it makes more sense to have such a general method in `RestRequestHandler`. Any thoughts?