### PR TITLE
PaginatedSearchResult, allow page size zero

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.40.0'
+version = '1.40.1'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility

--- a/pagination/src/main/java/no/unit/nva/commons/pagination/PaginatedSearchResult.java
+++ b/pagination/src/main/java/no/unit/nva/commons/pagination/PaginatedSearchResult.java
@@ -185,13 +185,9 @@ public final class PaginatedSearchResult<T> {
         if (isLessThanZero(offset)) {
             throw new UnprocessableContentException("Unable to process negative offset");
         }
-        if (isLessThanOrEqualToZero(size)) {
+        if (isLessThanZero(size)) {
             throw new UnprocessableContentException("Unable to process size equal to or less than zero");
         }
-    }
-
-    private static boolean isLessThanOrEqualToZero(int number) {
-        return isLessThanZero(number) || number == 0;
     }
 
     private static boolean isLessThanZero(int number) {

--- a/pagination/src/test/java/no/unit/nva/commons/pagination/PaginatedSearchResultTest.java
+++ b/pagination/src/test/java/no/unit/nva/commons/pagination/PaginatedSearchResultTest.java
@@ -137,7 +137,7 @@ class PaginatedSearchResultTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"10,0", "-1,10", "10,-1"})
+    @CsvSource({"-1,10", "10,-1"})
     void shouldThrowUnprocessableContentExceptionOnNonsenseRequest(int offset, int size) {
         assertThrows(UnprocessableContentException.class,
                      () -> PaginatedSearchResult.create(BASE_URI, offset, size, 50, Collections.emptyList(),


### PR DESCRIPTION
Suggest to allow page size zero, this is a relevant cases where you are only interested in aggregations, not hits.