### PR TITLE
Np 47133 UriWrapper, fix escaping ampersand

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.40.2'
+version = '1.40.3'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,8 @@ plugins {
 
 dependencies {
     implementation  libs.slf4j.api
-
+    implementation libs.javaxWsRs
+    implementation libs.jerseyClient
     compileOnly libs.jackson.annotations
     testImplementation libs.bundles.logging
     testImplementation libs.bundles.testing

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,8 +5,7 @@ plugins {
 
 dependencies {
     implementation  libs.slf4j.api
-    implementation libs.javaxWsRs
-    implementation libs.jerseyClient
+    implementation libs.httpclient5
     compileOnly libs.jackson.annotations
     testImplementation libs.bundles.logging
     testImplementation libs.bundles.testing

--- a/core/src/main/java/nva/commons/core/paths/UriWrapper.java
+++ b/core/src/main/java/nva/commons/core/paths/UriWrapper.java
@@ -6,8 +6,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Optional;
+import javax.ws.rs.core.UriBuilder;
 import nva.commons.core.JacocoGenerated;
-import nva.commons.core.StringUtils;
 import nva.commons.core.attempt.Try;
 
 /**
@@ -23,8 +23,6 @@ public class UriWrapper {
     public static final String MISSING_HOST = "Missing host for creating URI";
     public static final String HTTPS = "https";
     public static final String NULL_INPUT_ERROR = "Input URI cannot be null.";
-    public static final String ESCAPED_SPACE_AND_AMPERSAND = "%20&%20";
-    public static final String ESCAPED_SPACE_AND_ESCAPEDAMPERSAND = "%20%26%20";
     private static final int DEFAULT_PORT = -1;
     private final URI uri;
 
@@ -147,19 +145,7 @@ public class UriWrapper {
     }
 
     public UriWrapper addQueryParameter(String param, String value) {
-        var queryString = StringUtils.isBlank(uri.getQuery())
-                              ? param + "=" + value
-                              : uri.getQuery() + "&" + param + "=" + value;
-        URI newUri = attempt(() -> new URI(uri.getScheme(),
-                                           uri.getUserInfo(),
-                                           uri.getHost(),
-                                           uri.getPort(),
-                                           uri.getPath(),
-                                           queryString,
-                                           EMPTY_FRAGMENT))
-                         .map(this::escapeAmpersandsInQueryParameterValues)
-                         .orElseThrow();
-
+        var newUri = UriBuilder.fromUri(uri).queryParam(param, value).build();
         return new UriWrapper(newUri);
     }
 
@@ -192,10 +178,5 @@ public class UriWrapper {
 
     private static URI createUriFromHostDomain(String scheme, String host, int port) throws URISyntaxException {
         return new URI(scheme, EMPTY_USER_INFO, host, port, EMPTY_PATH, EMPTY_QUERY, EMPTY_FRAGMENT);
-    }
-
-    private URI escapeAmpersandsInQueryParameterValues(URI uri) {
-        var newUriString = uri.toString().replace(ESCAPED_SPACE_AND_AMPERSAND, ESCAPED_SPACE_AND_ESCAPEDAMPERSAND);
-        return URI.create(newUriString);
     }
 }

--- a/core/src/main/java/nva/commons/core/paths/UriWrapper.java
+++ b/core/src/main/java/nva/commons/core/paths/UriWrapper.java
@@ -6,9 +6,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Optional;
-import javax.ws.rs.core.UriBuilder;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Try;
+import org.apache.hc.core5.net.URIBuilder;
 
 /**
  * Class for easily building and manipulating URIs. Tools to easily append paths and not have to deal with checking
@@ -145,7 +145,10 @@ public class UriWrapper {
     }
 
     public UriWrapper addQueryParameter(String param, String value) {
-        var newUri = UriBuilder.fromUri(uri).queryParam(param, value).build();
+        var newUri = attempt(() -> new URIBuilder(uri)
+                                       .addParameter(param, value)
+                                       .build())
+                         .orElseThrow();
         return new UriWrapper(newUri);
     }
 

--- a/core/src/test/java/nva/commons/core/paths/UriWrapperTest.java
+++ b/core/src/test/java/nva/commons/core/paths/UriWrapperTest.java
@@ -112,11 +112,11 @@ class UriWrapperTest {
     @Test
     void shouldReturnUriWithEscapedAmpersandInQueryParameterValue() {
         URI expectedUri = URI.create(
-            "https://www.example.org/my-path?key1=someOtherValue&key2=some%20%26%20value&key3=valueWithout%26space");
+            "https://www.example.org/my-path?key1=someWonderfulSimpleValue&key2=some+%26+value&key3=valueWithout%26space");
         URI uri = URI.create("https://www.example.org/");
         URI actualUri = UriWrapper.fromUri(uri)
                             .addChild("my-path")
-                            .addQueryParameter("key1", "someOtherValue")
+                            .addQueryParameter("key1", "someWonderfulSimpleValue")
                             .addQueryParameter("key2", "some & value")
                             .addQueryParameter("key3", "valueWithout&space")
                             .getUri();

--- a/core/src/test/java/nva/commons/core/paths/UriWrapperTest.java
+++ b/core/src/test/java/nva/commons/core/paths/UriWrapperTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -110,19 +111,19 @@ class UriWrapperTest {
     }
 
     @Test
-    void shouldReturnUriWithEscapedAndInQueryParameterValue(){
-        URI expectedUri = URI.create("https://www.example.org/path1/path2?key1=some%20%26%20value");
+    void shouldReturnUriWithEscapedAmpersandInQueryParameterValue(){
+        URI expectedUri = URI.create("https://www.example.org/my-path?key1=someOtherValue&key2=some%20%26%20value");
         URI uri = URI.create("https://www.example.org/");
         URI actualUri = UriWrapper.fromUri(uri)
-                            .addChild("path1")
-                            .addQueryParameter("key1", "some & value")
-                            .addChild("path2")
+                            .addChild("my-path")
+                            .addQueryParameter("key1", "someOtherValue")
+                            .addQueryParameter("key2", "some & value")
                             .getUri();
         assertThat(actualUri, is(equalTo(expectedUri)));
     }
 
     @Test
-    void shouldPreservePortWhenAddingPathAndQueryPapametersInUri() {
+    void shouldPreservePortWhenAddingPathAndQueryParametersInUri() {
         var expectedUri = URI.create("https://www.example.org:1234/path1/path2?key1=value1");
         var host = URI.create("https://www.example.org:1234");
         var actualUri = UriWrapper.fromUri(host)

--- a/core/src/test/java/nva/commons/core/paths/UriWrapperTest.java
+++ b/core/src/test/java/nva/commons/core/paths/UriWrapperTest.java
@@ -112,7 +112,8 @@ class UriWrapperTest {
     @Test
     void shouldReturnUriWithEscapedAmpersandInQueryParameterValue() {
         URI expectedUri = URI.create(
-            "https://www.example.org/my-path?key1=someWonderfulSimpleValue&key2=some+%26+value&key3=valueWithout%26space");
+            "https://www.example.org/my-path?key1=someWonderfulSimpleValue&key2=some%20%26%20value&key3=valueWithout"
+            + "%26space");
         URI uri = URI.create("https://www.example.org/");
         URI actualUri = UriWrapper.fromUri(uri)
                             .addChild("my-path")

--- a/core/src/test/java/nva/commons/core/paths/UriWrapperTest.java
+++ b/core/src/test/java/nva/commons/core/paths/UriWrapperTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.net.URI;
-import java.net.URLEncoder;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -103,21 +102,23 @@ class UriWrapperTest {
         URI expectedUri = URI.create("https://www.example.org/path1/path2?key1=value1");
         URI uri = URI.create("https://www.example.org/");
         URI actualUri = UriWrapper.fromUri(uri)
-            .addChild("path1")
-            .addQueryParameter("key1", "value1")
-            .addChild("path2")
-            .getUri();
+                            .addChild("path1")
+                            .addQueryParameter("key1", "value1")
+                            .addChild("path2")
+                            .getUri();
         assertThat(actualUri, is(equalTo(expectedUri)));
     }
 
     @Test
-    void shouldReturnUriWithEscapedAmpersandInQueryParameterValue(){
-        URI expectedUri = URI.create("https://www.example.org/my-path?key1=someOtherValue&key2=some%20%26%20value");
+    void shouldReturnUriWithEscapedAmpersandInQueryParameterValue() {
+        URI expectedUri = URI.create(
+            "https://www.example.org/my-path?key1=someOtherValue&key2=some%20%26%20value&key3=valueWithout%26space");
         URI uri = URI.create("https://www.example.org/");
         URI actualUri = UriWrapper.fromUri(uri)
                             .addChild("my-path")
                             .addQueryParameter("key1", "someOtherValue")
                             .addQueryParameter("key2", "some & value")
+                            .addQueryParameter("key3", "valueWithout&space")
                             .getUri();
         assertThat(actualUri, is(equalTo(expectedUri)));
     }
@@ -127,10 +128,10 @@ class UriWrapperTest {
         var expectedUri = URI.create("https://www.example.org:1234/path1/path2?key1=value1");
         var host = URI.create("https://www.example.org:1234");
         var actualUri = UriWrapper.fromUri(host)
-            .addChild("path1")
-            .addQueryParameter("key1", "value1")
-            .addChild("path2")
-            .getUri();
+                            .addChild("path1")
+                            .addQueryParameter("key1", "value1")
+                            .addChild("path2")
+                            .getUri();
         assertThat(actualUri, is(equalTo(expectedUri)));
     }
 
@@ -139,11 +140,11 @@ class UriWrapperTest {
         URI expectedUri = URI.create("https://www.example.org/path1/path2?key1=value1&key2=value2");
         URI uri = URI.create("https://www.example.org/");
         URI actualUri = UriWrapper.fromUri(uri)
-            .addChild("path1")
-            .addQueryParameter("key1", "value1")
-            .addQueryParameter("key2", "value2")
-            .addChild("path2")
-            .getUri();
+                            .addChild("path1")
+                            .addQueryParameter("key1", "value1")
+                            .addQueryParameter("key2", "value2")
+                            .addChild("path2")
+                            .getUri();
         assertThat(actualUri, is(equalTo(expectedUri)));
     }
 
@@ -153,11 +154,11 @@ class UriWrapperTest {
         URI uri = URI.create("https://www.example.org/");
         final Map<String, String> parameters = getOrderedParametersMap();
         URI actualUri = UriWrapper.fromUri(uri)
-            .addChild("path1")
-            .addQueryParameters(parameters)
-            .addChild("path2")
-            .addQueryParameter("key3", "value3")
-            .getUri();
+                            .addChild("path1")
+                            .addQueryParameters(parameters)
+                            .addChild("path2")
+                            .addQueryParameter("key3", "value3")
+                            .getUri();
         assertThat(actualUri, is(equalTo(expectedUri)));
     }
 
@@ -165,15 +166,14 @@ class UriWrapperTest {
     void shouldReturnStringRepresentationOfUri() {
         URI expectedUri = URI.create("https://www.example.org/path1/path2?key1=value1&key2=value2&key3=value3");
         UriWrapper uri = new UriWrapper("https", "www.example.org")
-            .addChild("path1")
-            .addChild("path2")
-            .addQueryParameter("key1", "value1")
-            .addQueryParameter("key2", "value2")
-            .addQueryParameter("key3", "value3");
+                             .addChild("path1")
+                             .addChild("path2")
+                             .addQueryParameter("key1", "value1")
+                             .addQueryParameter("key2", "value2")
+                             .addQueryParameter("key3", "value3");
 
         assertThat(uri.toString(), is(equalTo(expectedUri.toString())));
     }
-
 
     @ParameterizedTest(name = "should throw exception when either host is empty")
     @NullAndEmptySource

--- a/core/src/test/java/nva/commons/core/paths/UriWrapperTest.java
+++ b/core/src/test/java/nva/commons/core/paths/UriWrapperTest.java
@@ -110,6 +110,18 @@ class UriWrapperTest {
     }
 
     @Test
+    void shouldReturnUriWithEscapedAndInQueryParameterValue(){
+        URI expectedUri = URI.create("https://www.example.org/path1/path2?key1=some%20%26%20value");
+        URI uri = URI.create("https://www.example.org/");
+        URI actualUri = UriWrapper.fromUri(uri)
+                            .addChild("path1")
+                            .addQueryParameter("key1", "some & value")
+                            .addChild("path2")
+                            .getUri();
+        assertThat(actualUri, is(equalTo(expectedUri)));
+    }
+
+    @Test
     void shouldPreservePortWhenAddingPathAndQueryPapametersInUri() {
         var expectedUri = URI.create("https://www.example.org:1234/path1/path2?key1=value1");
         var host = URI.create("https://www.example.org:1234");

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,8 +23,7 @@ apiGuardian = { strictly = '1.1.2' }
 wiremock = { strictly = '3.4.1' }
 datafaker = { strictly = '2.1.0' }
 com-auth0-jwt = { strictly = '4.4.0' }
-javaxWsRs = { strictly = '2.1.1' }
-jersey = { strictly = '2.34' }
+apacheHttpClient = { strictly = '5.3.1' }
 
 [libraries]
 zalando = { group = 'org.zalando', name = 'problem', version.ref = 'zalandoProblem' }
@@ -84,14 +83,13 @@ hamcrest-core = { group = 'org.hamcrest', name = 'hamcrest-core', version.ref = 
 mockito-core = { group = 'org.mockito', name = 'mockito-core', version.ref = 'mockito' }
 hamcrest-optional = { group = 'com.github.npathai', name = 'hamcrest-optional', version.ref = 'hamcrestOptional' }
 datafaker = { group = 'net.datafaker', name = 'datafaker', version.ref = 'datafaker' }
-javaxWsRs = { group = 'javax.ws.rs', name = 'javax.ws.rs-api', version.ref = 'javaxWsRs' }
-jerseyClient = { group = 'org.glassfish.jersey.core', name = 'jersey-client', version.ref = 'jersey' }
+httpclient5 = { group = 'org.apache.httpcomponents.client5', name = 'httpclient5', version.ref = 'apacheHttpClient' }
 
 apiguardian = { group = 'org.apiguardian', name = 'apiguardian-api', version.ref = 'apiGuardian' }
 wiremock = { group = 'org.wiremock', name = 'wiremock', version.ref = 'wiremock' }
 
 
-com-auth0-jwt = { group = 'com.auth0', name =  'java-jwt', version.ref = 'com-auth0-jwt' }
+com-auth0-jwt = { group = 'com.auth0', name = 'java-jwt', version.ref = 'com-auth0-jwt' }
 
 [bundles]
 testing = ['mockito-core', 'hamcrest', 'hamcrest-core', 'junit-jupiter', 'junit-jupiter-api',

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ apiGuardian = { strictly = '1.1.2' }
 wiremock = { strictly = '3.4.1' }
 datafaker = { strictly = '2.1.0' }
 com-auth0-jwt = { strictly = '4.4.0' }
+javaxWsRs = { strictly = '2.1.1' }
+jersey = { strictly = '2.34' }
 
 [libraries]
 zalando = { group = 'org.zalando', name = 'problem', version.ref = 'zalandoProblem' }
@@ -82,6 +84,8 @@ hamcrest-core = { group = 'org.hamcrest', name = 'hamcrest-core', version.ref = 
 mockito-core = { group = 'org.mockito', name = 'mockito-core', version.ref = 'mockito' }
 hamcrest-optional = { group = 'com.github.npathai', name = 'hamcrest-optional', version.ref = 'hamcrestOptional' }
 datafaker = { group = 'net.datafaker', name = 'datafaker', version.ref = 'datafaker' }
+javaxWsRs = { group = 'javax.ws.rs', name = 'javax.ws.rs-api', version.ref = 'javaxWsRs' }
+jerseyClient = { group = 'org.glassfish.jersey.core', name = 'jersey-client', version.ref = 'jersey' }
 
 apiguardian = { group = 'org.apiguardian', name = 'apiguardian-api', version.ref = 'apiGuardian' }
 wiremock = { group = 'org.wiremock', name = 'wiremock', version.ref = 'wiremock' }


### PR DESCRIPTION
_NP-47133 Search publication channel, too many search results when query contains ampersand_

Bug: ampersands in query parameters were not being escaped

Tried solving this without new dependency, but the code was not pretty... If you have suggestions for other ways of solving this, please leave a comment!