### PR TITLE
restrict-allow-origin

### DIFF
--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
@@ -300,7 +300,7 @@ public abstract class ApiGatewayHandler<I, O> extends RestRequestHandler<I, O> {
         headers.put(CONTENT_TYPE, MediaTypes.APPLICATION_PROBLEM_JSON.toString());
         headers.put(X_CONTENT_TYPE_OPTIONS, "nosniff");
         headers.put(STRICT_TRANSPORT_SECURITY, "max-age=63072000; includeSubDomains; preload");
-        headers.put(VARY, "Origin");
+        headers.put(VARY, "Origin, Accept");
         return headers;
     }
 

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
@@ -310,7 +310,7 @@ public abstract class ApiGatewayHandler<I, O> extends RestRequestHandler<I, O> {
         headers.put(CONTENT_TYPE, getDefaultResponseContentTypeHeaderValue(requestInfo).toString());
         headers.put(X_CONTENT_TYPE_OPTIONS, "nosniff");
         headers.put(STRICT_TRANSPORT_SECURITY, "max-age=63072000; includeSubDomains; preload");
-        headers.put(VARY, "Origin");
+        headers.put(VARY, "Origin, Accept");
         return headers;
     }
 

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
@@ -92,7 +92,7 @@ public abstract class ApiGatewayHandler<I, O> extends RestRequestHandler<I, O> {
 
     private List<String> getValidOrigins() {
         return Arrays.stream(environment.readEnv(ALLOWED_ORIGIN_ENV).split(ORIGIN_DELIMITER))
-                   .map(String::trim)
+                   .map(String::strip)
                    .filter(StringUtils::isNotBlank)
                    .toList();
     }

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
@@ -3,20 +3,21 @@ package nva.commons.apigateway;
 import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.HttpHeaders.STRICT_TRANSPORT_SECURITY;
+import static com.google.common.net.HttpHeaders.VARY;
 import static com.google.common.net.HttpHeaders.X_CONTENT_TYPE_OPTIONS;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static nva.commons.apigateway.RestConfig.defaultRestObjectMapper;
-import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,6 +29,7 @@ import nva.commons.apigateway.exceptions.RedirectException;
 import nva.commons.apigateway.exceptions.UnsupportedAcceptHeaderException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
+import nva.commons.core.StringUtils;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 import org.zalando.problem.ThrowableProblem;
@@ -42,6 +44,9 @@ public abstract class ApiGatewayHandler<I, O> extends RestRequestHandler<I, O> {
     public static final String REQUEST_ID = "requestId";
     public static final Void EMPTY_BODY = null;
     public static final String RESOURCE = "resource";
+    public static final String ALL_ORIGINS_ALLOWED = "*";
+    public static final String ORIGIN_DELIMITER = ",";
+    public static final String FALLBACK_ORIGIN  = "https://nva.sikt.no";
 
     private final ObjectMapper objectMapper;
 
@@ -64,9 +69,32 @@ public abstract class ApiGatewayHandler<I, O> extends RestRequestHandler<I, O> {
     }
 
     @Override
-    public void init(OutputStream outputStream, Context context) {
-        this.allowedOrigin = environment.readEnv(ALLOWED_ORIGIN_ENV);
-        super.init(outputStream, context);
+    protected void setAllowedOrigin(RequestInfo requestInfo) {
+        allowedOrigin = readAllowedOrigin(requestInfo);
+    }
+
+
+
+    private String readAllowedOrigin(RequestInfo requestInfo) {
+        var originsList = getValidOrigins();
+        if (originsList.isEmpty()){
+            return FALLBACK_ORIGIN;
+        }
+        if (originsList.contains(ALL_ORIGINS_ALLOWED)) {
+            return ALL_ORIGINS_ALLOWED;
+        }
+        var requestOrigin = requestInfo.getHeader("Origin");
+        if (originsList.contains(requestOrigin)) {
+            return requestOrigin;
+        }
+        return originsList.get(0);
+    }
+
+    private List<String> getValidOrigins() {
+        return Arrays.stream(environment.readEnv(ALLOWED_ORIGIN_ENV).split(ORIGIN_DELIMITER))
+                   .map(String::trim)
+                   .filter(StringUtils::isNotBlank)
+                   .toList();
     }
 
     /**
@@ -272,6 +300,7 @@ public abstract class ApiGatewayHandler<I, O> extends RestRequestHandler<I, O> {
         headers.put(CONTENT_TYPE, MediaTypes.APPLICATION_PROBLEM_JSON.toString());
         headers.put(X_CONTENT_TYPE_OPTIONS, "nosniff");
         headers.put(STRICT_TRANSPORT_SECURITY, "max-age=63072000; includeSubDomains; preload");
+        headers.put(VARY, "Origin");
         return headers;
     }
 
@@ -281,6 +310,7 @@ public abstract class ApiGatewayHandler<I, O> extends RestRequestHandler<I, O> {
         headers.put(CONTENT_TYPE, getDefaultResponseContentTypeHeaderValue(requestInfo).toString());
         headers.put(X_CONTENT_TYPE_OPTIONS, "nosniff");
         headers.put(STRICT_TRANSPORT_SECURITY, "max-age=63072000; includeSubDomains; preload");
+        headers.put(VARY, "Origin");
         return headers;
     }
 

--- a/apigateway/src/main/java/nva/commons/apigateway/RestRequestHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/RestRequestHandler.java
@@ -49,6 +49,7 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
 
     private static final List<MediaType> DEFAULT_SUPPORTED_MEDIA_TYPES = List.of(JSON_UTF_8);
     private static final String WILDCARD_TYPE = "*";
+    public static final String ALLOW_ALL_ORIGINS  = "*";
 
     /**
      * Calculates the Content MediaType of the response based on the supported Media Types and the requested Media
@@ -145,6 +146,7 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
                               .orElseThrow(this::parsingExceptionToBadRequestException);
 
             RequestInfo requestInfo = inputParser.getRequestInfo(inputString);
+            setAllowedOrigin(requestInfo);
 
             validateRequest(inputObject, requestInfo, context);
 
@@ -157,6 +159,9 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
             handleUnexpectedException(context, inputObject, e);
         }
     }
+
+
+    protected abstract void setAllowedOrigin(RequestInfo requestInfo);
 
     /**
      * Implements input validation and access control.
@@ -190,6 +195,8 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
 
     protected void init(OutputStream outputStream, Context context) {
         this.outputStream = outputStream;
+        this.allowedOrigin = ALLOW_ALL_ORIGINS; //anti-pattern: this will be overwritten later on, but in the event
+        // that we get an exception before we get there, there is this.
     }
 
     /**

--- a/apigateway/src/test/java/nva/commons/apigateway/VoidTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/VoidTest.java
@@ -1,5 +1,6 @@
 package nva.commons.apigateway;
 
+import static nva.commons.apigateway.ApiGatewayHandler.ALLOWED_ORIGIN_ENV;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -40,6 +41,7 @@ public class VoidTest {
         environment = mock(Environment.class);
         context = new FakeContext();
         when(environment.readEnv(anyString())).thenReturn(SOME_ENV_VALUE);
+        when(environment.readEnv(ALLOWED_ORIGIN_ENV)).thenReturn("*");
     }
 
     @DisplayName("handleRequest returns success when input class is void and body field is missing from "

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/RawStringResponseHandler.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/RawStringResponseHandler.java
@@ -38,6 +38,10 @@ public class RawStringResponseHandler extends ApiGatewayHandler<RequestBody, Str
         super(RequestBody.class, new Environment(), mapper);
     }
 
+    public RawStringResponseHandler(Environment environment, ObjectMapper mapper) {
+        super(RequestBody.class, environment, mapper);
+    }
+
 
     @Override
     protected String processInput(RequestBody input, RequestInfo requestInfo, Context context)

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.40.3'
+version = '1.40.4'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility


### PR DESCRIPTION
Only one domain can be returned when setting the Access-allow-origin-header.

If we have multiple supported origins, we need to echo the request.header.origin back to the client with the Vary header also set after checking a whitelist.


We probably going to need to be able to set a list of allowed origins, because there are a multiple of frontends that are served from the same backend. Ex. frontenders running their code locally, and having a temporary branch deployed for testers.


This PR will also be a nightmare for our frontenders: https://stackoverflow.com/questions/10883211/why-does-my-http-localhost-cors-origin-not-work