### PR TITLE
Fix bug that occurs when a URI with encoded query params is passed to…

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.40.8'
+version = '1.40.9'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.40.9'
+version = '1.40.10'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility

--- a/core/src/main/java/nva/commons/core/paths/UriWrapper.java
+++ b/core/src/main/java/nva/commons/core/paths/UriWrapper.java
@@ -1,13 +1,21 @@
 package nva.commons.core.paths;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Try;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.hc.core5.net.URIBuilder;
 
 /**
@@ -23,7 +31,11 @@ public class UriWrapper {
     public static final String MISSING_HOST = "Missing host for creating URI";
     public static final String HTTPS = "https";
     public static final String NULL_INPUT_ERROR = "Input URI cannot be null.";
-    private static final int DEFAULT_PORT = -1;
+    private static final int VALUE = 1;
+    private static final int DEFAULT_PORT = -VALUE;
+    private static final String AMPERSAND = "&";
+    private static final String ASSIGNMENT = "=";
+    private static final int NO_MATCH = -1;
     private URI uri;
 
     @JacocoGenerated
@@ -146,8 +158,10 @@ public class UriWrapper {
 
     public UriWrapper addQueryParameter(String param, String value) {
         this.uri = attempt(() -> new URIBuilder(uri)
-                                       .addParameter(param, value)
-                                       .build())
+                                     .removeQuery()
+                                     .addParameters(extractUriQueryParameters())
+                                     .addParameter(param, value)
+                                     .build())
                          .orElseThrow();
         return this;
     }
@@ -181,5 +195,35 @@ public class UriWrapper {
 
     private static URI createUriFromHostDomain(String scheme, String host, int port) throws URISyntaxException {
         return new URI(scheme, EMPTY_USER_INFO, host, port, EMPTY_PATH, EMPTY_QUERY, EMPTY_FRAGMENT);
+    }
+
+    private List<NameValuePair> extractUriQueryParameters() {
+        var query = uri.getRawQuery();
+        return nonNull(query)
+                   ? extractKeyValuePairs(query)
+                   : Collections.emptyList();
+    }
+
+    private static List<NameValuePair> extractKeyValuePairs(String query) {
+        return Arrays.stream(splitKeyValuePairs(query))
+                   .map(UriWrapper::createNameValuePair)
+                   .toList();
+    }
+
+    private static NameValuePair createNameValuePair(String pairString) {
+        var assignation = pairString.indexOf(ASSIGNMENT);
+        if (assignation == NO_MATCH) {
+            return new BasicNameValuePair(decode(pairString), null);
+        }
+        return new BasicNameValuePair(decode(pairString.substring(0, assignation)),
+                                      decode(pairString.substring(assignation + 1)));
+    }
+
+    private static String decode(String encodedString) {
+        return URLDecoder.decode(encodedString, StandardCharsets.UTF_8);
+    }
+
+    private static String[] splitKeyValuePairs(String query) {
+        return query.split(AMPERSAND);
     }
 }


### PR DESCRIPTION
Fix bug that occurs when a URI with encoded query params is passed to UriWrapper and additional query params are added.

Testing multiple strange configurations since one never knows.