### PR TITLE
Np 46577 AuthorizedBackendClient, only refresh token when expired

### DIFF
--- a/auth/src/main/java/no/unit/nva/auth/AuthorizedBackendClient.java
+++ b/auth/src/main/java/no/unit/nva/auth/AuthorizedBackendClient.java
@@ -12,6 +12,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
@@ -29,6 +30,7 @@ public class AuthorizedBackendClient {
     public static final Map<String, String> GRANT_TYPE_CLIENT_CREDENTIALS = Map.of("grant_type", "client_credentials");
     private final HttpClient httpClient;
     private final CognitoCredentials cognitoCredentials;
+    private final CachedJwtProvider cachedJwtProvider;
     private final boolean bearerTokenIsNotInjectedDirectly;
     private String bearerToken;
 
@@ -38,6 +40,8 @@ public class AuthorizedBackendClient {
         this.httpClient = httpClient;
         this.bearerToken = bearerToken;
         this.cognitoCredentials = cognitoCredentials;
+        this.cachedJwtProvider = new CachedJwtProvider(new CognitoAuthenticator(httpClient, cognitoCredentials),
+                                                       Clock.systemDefaultZone());
         this.bearerTokenIsNotInjectedDirectly = isNull(bearerToken);
     }
 

--- a/auth/src/main/java/no/unit/nva/auth/AuthorizedBackendClient.java
+++ b/auth/src/main/java/no/unit/nva/auth/AuthorizedBackendClient.java
@@ -59,14 +59,14 @@ public class AuthorizedBackendClient {
 
     public <T> HttpResponse<T> send(HttpRequest.Builder request, BodyHandler<T> responseBodyHandler)
         throws IOException, InterruptedException {
-        refreshToken();
+        refreshTokenIfExpired();
         var authorizedRequest = request.setHeader(AUTHORIZATION_HEADER, bearerToken).build();
         return httpClient.send(authorizedRequest, responseBodyHandler);
     }
 
     public <T> CompletableFuture<HttpResponse<T>> sendAsync(Builder request,
                                                             BodyHandler<T> responseBodyHandler) {
-        refreshToken();
+        refreshTokenIfExpired();
         var authorizedRequest = request.setHeader(AUTHORIZATION_HEADER, bearerToken).build();
         return httpClient.sendAsync(authorizedRequest, responseBodyHandler);
     }
@@ -76,7 +76,7 @@ public class AuthorizedBackendClient {
         return bearerToken;
     }
 
-    private void refreshToken() {
+    private void refreshTokenIfExpired() {
         if (bearerTokenIsNotInjectedDirectly) {
             this.bearerToken = createBearerToken(cachedJwtProvider.getValue().getToken());
         }

--- a/auth/src/main/java/no/unit/nva/auth/CognitoAuthenticator.java
+++ b/auth/src/main/java/no/unit/nva/auth/CognitoAuthenticator.java
@@ -1,12 +1,14 @@
 package no.unit.nva.auth;
 
 import static com.amazonaws.auth.internal.SignerConstants.AUTHORIZATION;
+import static java.util.Objects.isNull;
 import static no.unit.nva.auth.AuthorizedBackendClient.APPLICATION_X_WWW_FORM_URLENCODED;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.apache.http.protocol.HTTP.CONTENT_TYPE;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.jr.ob.JSON;
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -40,7 +42,7 @@ public class CognitoAuthenticator {
                    .map(HttpResponse::body)
                    .map(JSON.std::mapFrom)
                    .map(json -> json.get(JWT_TOKEN_FIELD))
-                   .toOptional()
+                   .map(this::assertFieldIsPresent)
                    .map(Objects::toString)
                    .map(JWT::decode)
                    .orElseThrow();
@@ -52,6 +54,13 @@ public class CognitoAuthenticator {
 
     private static HttpRequest.BodyPublisher clientCredentialsAuthType() {
         return HttpRequest.BodyPublishers.ofString(GRANT_TYPE_CLIENT_CREDENTIALS);
+    }
+
+    private Object assertFieldIsPresent(Object object) {
+        if (isNull(object)) {
+            throw new IllegalStateException("Received token response without token");
+        }
+        return object;
     }
 
     private String formatAuthenticationHeaderValue() {
@@ -73,16 +82,18 @@ public class CognitoAuthenticator {
     }
 
     private HttpResponse<String> fetchTokenResponse() {
-        return attempt(
-            () -> this.httpClient.send(createTokenRequest(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
-        )
+        return attempt(this::sendTokenRequest)
                    .map(this::responseIsSuccessful)
                    .orElseThrow();
     }
 
+    private HttpResponse<String> sendTokenRequest() throws IOException, InterruptedException {
+        return this.httpClient.send(createTokenRequest(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
     private HttpResponse<String> responseIsSuccessful(HttpResponse<String> response) {
         if (HttpURLConnection.HTTP_OK != response.statusCode()) {
-            throw new RuntimeException(AUTHORIZATION_ERROR_MESSAGE);
+            throw UnexpectedHttpResponseException.fromHttpResponse(response);
         }
         return response;
     }

--- a/auth/src/main/java/no/unit/nva/auth/CognitoAuthenticator.java
+++ b/auth/src/main/java/no/unit/nva/auth/CognitoAuthenticator.java
@@ -25,7 +25,6 @@ public class CognitoAuthenticator {
     public static final String TOKEN_PATH_SEGMENT = "token";
     public static final String BASIC_AUTH_CREDENTIALS_TEMPLATE = "%s:%s";
     public static final String BASIC_AUTH_HEADER_TEMPLATE = "%s %s";
-    public static final String AUTHORIZATION_ERROR_MESSAGE = "Could not authorizer client";
     public static final String GRANT_TYPE_CLIENT_CREDENTIALS = "grant_type=client_credentials";
     public static final String JWT_TOKEN_FIELD = "access_token";
     private final CognitoCredentials credentials;

--- a/auth/src/test/java/no/unit/nva/auth/CognitoAuthenticatorTest.java
+++ b/auth/src/test/java/no/unit/nva/auth/CognitoAuthenticatorTest.java
@@ -4,14 +4,13 @@ import static com.amazonaws.auth.internal.SignerConstants.AUTHORIZATION;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static no.unit.nva.auth.AuthorizedBackendClient.APPLICATION_X_WWW_FORM_URLENCODED;
-import static no.unit.nva.auth.CognitoAuthenticator.AUTHORIZATION_ERROR_MESSAGE;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.apache.http.protocol.HTTP.CONTENT_TYPE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -24,7 +23,6 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.NoSuchElementException;
 import no.unit.nva.auth.utils.HttpRequestMetadataMatcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -101,13 +99,13 @@ class CognitoAuthenticatorTest {
     @Test
     void shouldThrowWhenResponseIsNotStructuredLikeAToken() throws IOException, InterruptedException {
         when(httpClient.<String>send(any(), any())).thenReturn(invalidResponse);
-        assertThrows(NoSuchElementException.class, () -> cognitoAuthenticator.fetchBearerToken());
+        assertThrows(IllegalStateException.class, () -> cognitoAuthenticator.fetchBearerToken());
     }
 
     @Test
     void shouldThrowWhenResponseIsNot200Ok() throws IOException, InterruptedException {
         when(httpClient.<String>send(any(), any())).thenReturn(errorResponse);
         var exception = assertThrows(RuntimeException.class, () -> cognitoAuthenticator.fetchBearerToken());
-        assertEquals(AUTHORIZATION_ERROR_MESSAGE, exception.getMessage());
+        assertTrue(exception.getMessage().contains("Got unexpected http response"));
     }
 }

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.40.9'
+version = '1.40.10'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.40.10'
+version = '1.40.11'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility

--- a/nvatestutils/src/main/java/no/unit/nva/stubs/FakeAuthServer.java
+++ b/nvatestutils/src/main/java/no/unit/nva/stubs/FakeAuthServer.java
@@ -29,9 +29,7 @@ import nva.commons.core.JacocoGenerated;
 
 public class FakeAuthServer {
 
-    public static final String ACCESS_TOKEN_TEMPLATE = """
-        {"access_token": "%s","expires_in": %s}
-        """;
+    public static final String ACCESS_TOKEN_TEMPLATE = "{\"access_token\": \"%s\"}";
     public static final String ACCESS_TOKEN_FORBIDDEN = randomString();
     public static final String FORBIDDEN_BODY = randomString();
     private WireMockServer httpServer;
@@ -59,9 +57,8 @@ public class FakeAuthServer {
     public String createHttpInteractions(String clientId,
                                          String clientSecret,
                                          String expectedAccessToken,
-                                         String exampleResourcePath,
-                                         int expectedExpiresIn) {
-        createOAuthAccessTokenResponse(clientId, clientSecret, expectedAccessToken, expectedExpiresIn);
+                                         String exampleResourcePath) {
+        createOAuthAccessTokenResponse(clientId, clientSecret, expectedAccessToken);
         return createResponseForProtectedContent(expectedAccessToken, exampleResourcePath);
     }
 
@@ -73,9 +70,8 @@ public class FakeAuthServer {
         return protectedContent;
     }
 
-    public void createOAuthAccessTokenResponse(String clientId, String clientSecret, String expectedAccessToken,
-                                               int expectedExpiresIn) {
-        var body = format(ACCESS_TOKEN_TEMPLATE, expectedAccessToken, expectedExpiresIn);
+    public void createOAuthAccessTokenResponse(String clientId, String clientSecret, String expectedAccessToken) {
+        var body = format(ACCESS_TOKEN_TEMPLATE, expectedAccessToken);
         stubFor(post(OAUTH_TOKEN)
                     .withBasicAuth(clientId, clientSecret)
                     .withRequestBody(new ContainsPattern("grant_type=client_credentials"))

--- a/nvatestutils/src/test/java/no/unit/nva/stubs/FakeAuthServerTest.java
+++ b/nvatestutils/src/test/java/no/unit/nva/stubs/FakeAuthServerTest.java
@@ -60,7 +60,7 @@ class FakeAuthServerTest {
         var accessToken = randomString();
         var exampleResourcePath = "/example";
         var protectedResource = authServer.createHttpInteractions(clientId, clientSecret, accessToken,
-                                                                  exampleResourcePath, 3600);
+                                                                  exampleResourcePath);
         var requestUri = UriWrapper.fromUri(authServer.getServerUri()).addChild(exampleResourcePath).getUri();
         var request = HttpRequest.newBuilder(requestUri)
                           .header(HttpHeaders.AUTHORIZATION, bearerToken(accessToken))
@@ -77,8 +77,7 @@ class FakeAuthServerTest {
         var clientId = randomString();
         var clientSecret = randomString();
         var exampleResourcePath = "/example";
-        authServer.createHttpInteractions(clientId, clientSecret, randomString(),
-                                          exampleResourcePath, 3600);
+        authServer.createHttpInteractions(clientId, clientSecret, randomString(), exampleResourcePath);
         var requestUri = UriWrapper.fromUri(authServer.getServerUri()).addChild(exampleResourcePath).getUri();
         var request = HttpRequest.newBuilder(requestUri)
                           .header(HttpHeaders.AUTHORIZATION, bearerToken(randomString()))

--- a/nvatestutils/src/test/java/no/unit/nva/stubs/FakeAuthServerTest.java
+++ b/nvatestutils/src/test/java/no/unit/nva/stubs/FakeAuthServerTest.java
@@ -60,7 +60,7 @@ class FakeAuthServerTest {
         var accessToken = randomString();
         var exampleResourcePath = "/example";
         var protectedResource = authServer.createHttpInteractions(clientId, clientSecret, accessToken,
-                                                                  exampleResourcePath);
+                                                                  exampleResourcePath, 3600);
         var requestUri = UriWrapper.fromUri(authServer.getServerUri()).addChild(exampleResourcePath).getUri();
         var request = HttpRequest.newBuilder(requestUri)
                           .header(HttpHeaders.AUTHORIZATION, bearerToken(accessToken))
@@ -78,7 +78,7 @@ class FakeAuthServerTest {
         var clientSecret = randomString();
         var exampleResourcePath = "/example";
         authServer.createHttpInteractions(clientId, clientSecret, randomString(),
-                                          exampleResourcePath);
+                                          exampleResourcePath, 3600);
         var requestUri = UriWrapper.fromUri(authServer.getServerUri()).addChild(exampleResourcePath).getUri();
         var request = HttpRequest.newBuilder(requestUri)
                           .header(HttpHeaders.AUTHORIZATION, bearerToken(randomString()))


### PR DESCRIPTION
Experiencing issues during batch scan, Cognito responding with 429 (Too many requests) when requesting tokens. To reduce traffic:
- Use `CachedJwtProvider` in `AuthorizedBackendClient`, only refresh token if expired
- Moved [newly implemented error handling](https://github.com/BIBSYSDEV/nva-commons/pull/509) (by @sondrev) from `AuthorizedBackendClient` to `CognitoAuthenticator`.