### PR TITLE
NP-47422 AuthorizedBackendUriRetriever, dependency AuthorizedBackendClient

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.40.11'
+version = '1.40.12'
 
 
 java.sourceCompatibility = JavaVersion.VERSION_17  // source-code version and must be <= targetCompatibility


### PR DESCRIPTION
Instead of creating a new `AuthorizedBackendClient` for every request, use same client.
`AuthorizedBackendClient` manages valid tokens for requests with provided credentials