### PR TITLE
Add JWT testing tool

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.40.17'
+version = '1.40.18'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/nvatestutils/build.gradle
+++ b/nvatestutils/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation libs.wiremock.jetty.'12'
     implementation libs.bundles.jackson
     implementation libs.commons.validator
+    implementation libs.com.auth0.jwt
 
     testImplementation project(":doi")
 }

--- a/nvatestutils/src/main/java/no/unit/nva/testutils/JwtTestToken.java
+++ b/nvatestutils/src/main/java/no/unit/nva/testutils/JwtTestToken.java
@@ -1,0 +1,60 @@
+package no.unit.nva.testutils;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Provides random JWTs for testing purposes. It has DELIBERATELY limited functionality to avoid misuse.
+ */
+public final class JwtTestToken {
+
+    private JwtTestToken() {
+        // NO-OP
+    }
+
+    /**
+     * Creates a random valid, current JWT.
+     *
+     * @return String representation of the JWT.
+     */
+    public static String randomToken() {
+        var issuedAt = new Date();
+        var expiresAt = new Date(issuedAt.getTime() + TimeUnit.HOURS.toMillis(1));
+        return randomToken(issuedAt, expiresAt);
+    }
+
+    /**
+     * Creates a random valid, expired JWT.
+     *
+     * @return String representation of the expired JWT.
+     */
+    public static String randomExpiredToken() {
+        var issuedAt = new Date(new Date().getTime() - TimeUnit.HOURS.toMillis(1));
+        var expiresAt = new Date(issuedAt.getTime() + TimeUnit.MINUTES.toMillis(1));
+        return randomToken(issuedAt, expiresAt);
+    }
+
+    private static String randomToken(Date issuedAt, Date expiresAt) {
+        return newToken(randomString(),
+                        randomString(),
+                        issuedAt,
+                        expiresAt,
+                        Algorithm.HMAC256(randomString()));
+    }
+
+    private static String newToken(String issuer,
+                                   String subject,
+                                   Date issuedAt,
+                                   Date expiresAt,
+                                   Algorithm algorithm) {
+        return JWT.create()
+                   .withIssuer(issuer)
+                   .withSubject(subject)
+                   .withIssuedAt(issuedAt)
+                   .withExpiresAt(expiresAt)
+                   .sign(algorithm);
+    }
+}

--- a/nvatestutils/src/test/java/no/unit/nva/testutils/JwtTestTokenTest.java
+++ b/nvatestutils/src/test/java/no/unit/nva/testutils/JwtTestTokenTest.java
@@ -1,0 +1,22 @@
+package no.unit.nva.testutils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import com.auth0.jwt.JWT;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+
+class JwtTestTokenTest {
+
+    @Test
+    void shouldCreateRandomJwt() {
+        var actual = JwtTestToken.randomToken();
+        assertThat(JWT.decode(actual).getExpiresAt().after(new Date()), is(true));
+    }
+
+    @Test
+    void shouldCreateRandomExpiredJwt() {
+        var actual = JwtTestToken.randomExpiredToken();
+        assertThat(JWT.decode(actual).getExpiresAt().before(new Date()), is(true));
+    }
+}


### PR DESCRIPTION
We do a lot of `randomString()` where a JWT as expected. Previously, this has not been an issue,  but since upgrading various things in commons, things have tightened up.