### PR TITLE
adding addition methods to identity service client

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version = '1.41.4'
+version = '1.41.5'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/clients/src/main/java/no/unit/nva/clients/CustomerList.java
+++ b/clients/src/main/java/no/unit/nva/clients/CustomerList.java
@@ -1,0 +1,7 @@
+package no.unit.nva.clients;
+
+import java.util.List;
+
+public record CustomerList(List<GetCustomerResponse> customers) {
+
+}

--- a/clients/src/main/java/no/unit/nva/clients/GetCustomerResponse.java
+++ b/clients/src/main/java/no/unit/nva/clients/GetCustomerResponse.java
@@ -2,11 +2,17 @@ package no.unit.nva.clients;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
+import java.util.List;
 import java.util.UUID;
 import no.unit.nva.commons.json.JsonSerializable;
 
 public record GetCustomerResponse(@JsonProperty("id") URI id, UUID identifier, String name, String displayName,
-                                  String shortName,
-                                  URI cristinId) implements JsonSerializable {
+                                  String shortName, URI cristinId, String publicationWorkflow, boolean nviInstitution,
+                                  boolean rboInstitution, boolean generalSupportEnabled,
+                                  List<String> allowFileUploadForTypes, RightsRetentionStrategy rightsRetentionStrategy)
+    implements JsonSerializable {
 
+    public record RightsRetentionStrategy(String type, URI id) {
+
+    }
 }

--- a/clients/src/main/java/no/unit/nva/clients/IdentityServiceClient.java
+++ b/clients/src/main/java/no/unit/nva/clients/IdentityServiceClient.java
@@ -14,6 +14,7 @@ import java.net.http.HttpResponse;
 import java.util.concurrent.Callable;
 import no.unit.nva.auth.AuthorizedBackendClient;
 import no.unit.nva.auth.CognitoCredentials;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
@@ -93,6 +94,31 @@ public class IdentityServiceClient {
                    .map(this::validateResponse)
                    .map(r -> mapResponse(GetCustomerResponse.class, r))
                    .orElseThrow(this::handleFailure);
+    }
+
+    public GetCustomerResponse getCustomerById(URI customerId) throws NotFoundException {
+        var request = HttpRequest.newBuilder()
+                          .GET()
+                          .uri(customerId);
+        return attempt(getHttpResponseCallable(request))
+                   .map(this::validateResponse)
+                   .map(r -> mapResponse(GetCustomerResponse.class, r))
+                   .orElseThrow(this::handleFailure);
+    }
+
+    public CustomerList getAllCustomers() throws ApiGatewayException {
+        var request = HttpRequest.newBuilder()
+                          .GET()
+                          .uri(constructListCustomerUri());
+        return attempt(getHttpResponseCallable(request))
+                   .map(this::validateResponse)
+                   .map(HttpResponse::body)
+                   .map(value -> dtoObjectMapper.readValue(value, CustomerList.class))
+                   .orElseThrow(this::handleFailure);
+    }
+
+    private URI constructListCustomerUri() {
+        return UriWrapper.fromHost(API_HOST).addChild(CUSTOMER_PATH_PARAM).getUri();
     }
 
     private URI constructCustomerGetPath(URI topLevelOrgCristinId) {


### PR DESCRIPTION
Adding methods for fetching customer by id and listing all customers to IdentityServiceClient, so there is noe need to implement "complex configured" http client each time we need to make authenticated request to identity-service.