### PR TITLE
feature(apigateway): remove online query in request info #NP-48657

### DIFF
--- a/apigateway/src/main/java/nva/commons/apigateway/AccessRightEntry.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/AccessRightEntry.java
@@ -29,22 +29,10 @@ public class AccessRightEntry {
         return new AccessRightEntry(accessRight, customerId);
     }
 
-    public static AccessRightEntry fromStringForCustomer(String accessRightAtCustomer, URI customerId) {
-        var list = accessRightAtCustomer.split(AT);
-        var accessRight = AccessRight.fromPersistedString(list[ACCESS_RIGHT_INDEX]);
-        return new AccessRightEntry(accessRight, customerId);
-    }
-
     public static Stream<AccessRightEntry> fromCsv(String csv) {
         return Arrays.stream(csv.split(ENTRIIES_DELIMITER))
             .filter(not(String::isBlank))
             .map(AccessRightEntry::fromString);
-    }
-
-    public static Stream<AccessRightEntry> fromCsvForCustomer(String csv, URI customerId) {
-        return Arrays.stream(csv.split(ENTRIIES_DELIMITER))
-                   .filter(not(String::isBlank))
-                   .map(accessRightEntryStr -> fromStringForCustomer(accessRightEntryStr, customerId));
     }
 
     @JacocoGenerated

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayHandler.java
@@ -17,7 +17,6 @@ import com.google.common.net.MediaType;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
@@ -57,11 +56,11 @@ public abstract class ApiGatewayHandler<I, O> extends RestRequestHandler<I, O> {
     private boolean isBase64Encoded;
 
     public ApiGatewayHandler(Class<I> iclass) {
-        this(iclass, new Environment(), HttpClient.newBuilder().build());
+        this(iclass, new Environment());
     }
 
-    public ApiGatewayHandler(Class<I> iclass, Environment environment, HttpClient httpClient) {
-        super(iclass, environment, defaultRestObjectMapper, httpClient);
+    public ApiGatewayHandler(Class<I> iclass, Environment environment) {
+        super(iclass, environment, defaultRestObjectMapper);
         this.additionalSuccessHeadersSupplier = Collections::emptyMap;
     }
 

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayProxyHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiGatewayProxyHandler.java
@@ -1,7 +1,6 @@
 package nva.commons.apigateway;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import java.net.http.HttpClient;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
@@ -18,12 +17,12 @@ public abstract class ApiGatewayProxyHandler<I, O> extends ApiGatewayHandler<I, 
 
     @JacocoGenerated
     protected ApiGatewayProxyHandler(Class<I> iclass) {
-        this(iclass, new Environment(), HttpClient.newBuilder().build());
+        this(iclass, new Environment());
     }
     
     @JacocoGenerated
-    protected ApiGatewayProxyHandler(Class<I> iclass, Environment environment, HttpClient httpClient) {
-        super(iclass, environment, httpClient);
+    protected ApiGatewayProxyHandler(Class<I> iclass, Environment environment) {
+        super(iclass, environment);
     }
 
     @Override

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiS3GatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiS3GatewayHandler.java
@@ -1,7 +1,6 @@
 package nva.commons.apigateway;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import java.net.http.HttpClient;
 import java.time.Duration;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.Environment;
@@ -28,9 +27,8 @@ public abstract class ApiS3GatewayHandler<I> extends ApiS3PresignerGatewayHandle
     public ApiS3GatewayHandler(Class<I> iclass,
                                S3Client s3client,
                                S3Presigner s3Presigner,
-                               Environment environment,
-                               HttpClient httpClient) {
-        super(iclass, s3Presigner, environment, httpClient);
+                               Environment environment) {
+        super(iclass, s3Presigner, environment);
         this.s3client = s3client;
     }
 

--- a/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/ApiS3PresignerGatewayHandler.java
@@ -2,7 +2,6 @@ package nva.commons.apigateway;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
-import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.Map;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
@@ -30,9 +29,8 @@ public abstract class ApiS3PresignerGatewayHandler<I> extends ApiGatewayHandler<
     @JacocoGenerated
     public ApiS3PresignerGatewayHandler(Class<I> iclass,
                                         S3Presigner s3Presigner,
-                                        Environment environment,
-                                        HttpClient httpClient) {
-        super(iclass, environment, httpClient);
+                                        Environment environment) {
+        super(iclass, environment);
         this.s3presigner = s3Presigner;
     }
 

--- a/apigateway/src/main/java/nva/commons/apigateway/RequestInfo.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/RequestInfo.java
@@ -5,14 +5,10 @@ import static java.util.function.Predicate.not;
 import static no.unit.nva.auth.CognitoUserInfo.ELEMENTS_DELIMITER;
 import static nva.commons.apigateway.RequestInfoConstants.AUTHORIZATION_FAILURE_WARNING;
 import static nva.commons.apigateway.RequestInfoConstants.BACKEND_SCOPE_AS_DEFINED_IN_IDENTITY_SERVICE;
+import static nva.commons.apigateway.RequestInfoConstants.CLAIMS_PATH;
 import static nva.commons.apigateway.RequestInfoConstants.CLIENT_ID;
-import static nva.commons.apigateway.RequestInfoConstants.CUSTOMER_ID;
-import static nva.commons.apigateway.RequestInfoConstants.DEFAULT_COGNITO_URI;
 import static nva.commons.apigateway.RequestInfoConstants.DOMAIN_NAME_FIELD;
-import static nva.commons.apigateway.RequestInfoConstants.EXTERNAL_USER_POOL_URI;
-import static nva.commons.apigateway.RequestInfoConstants.FEIDE_ID;
 import static nva.commons.apigateway.RequestInfoConstants.HEADERS_FIELD;
-import static nva.commons.apigateway.RequestInfoConstants.ISS;
 import static nva.commons.apigateway.RequestInfoConstants.METHOD_ARN_FIELD;
 import static nva.commons.apigateway.RequestInfoConstants.MISSING_FROM_HEADERS;
 import static nva.commons.apigateway.RequestInfoConstants.MISSING_FROM_PATH_PARAMETERS;
@@ -21,17 +17,10 @@ import static nva.commons.apigateway.RequestInfoConstants.MISSING_FROM_REQUEST_C
 import static nva.commons.apigateway.RequestInfoConstants.MULTI_VALUE_QUERY_STRING_PARAMETERS_FIELD;
 import static nva.commons.apigateway.RequestInfoConstants.PATH_FIELD;
 import static nva.commons.apigateway.RequestInfoConstants.PATH_PARAMETERS_FIELD;
-import static nva.commons.apigateway.RequestInfoConstants.PERSON_AFFILIATION;
-import static nva.commons.apigateway.RequestInfoConstants.PERSON_CRISTIN_ID;
 import static nva.commons.apigateway.RequestInfoConstants.PERSON_GROUPS;
-import static nva.commons.apigateway.RequestInfoConstants.PERSON_NIN;
 import static nva.commons.apigateway.RequestInfoConstants.QUERY_STRING_PARAMETERS_FIELD;
 import static nva.commons.apigateway.RequestInfoConstants.REQUEST_CONTEXT_FIELD;
 import static nva.commons.apigateway.RequestInfoConstants.SCOPES_CLAIM;
-import static nva.commons.apigateway.RequestInfoConstants.TOP_LEVEL_ORG_CRISTIN_ID;
-import static nva.commons.apigateway.RequestInfoConstants.USER_NAME;
-import static nva.commons.apigateway.RequestInfoConstants.VIEWING_SCOPE_EXCLUDED;
-import static nva.commons.apigateway.RequestInfoConstants.VIEWING_SCOPE_INCLUDED;
 import static nva.commons.apigateway.RestConfig.defaultRestObjectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 import static nva.commons.core.paths.UriWrapper.HTTPS;
@@ -45,7 +34,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.net.HttpHeaders;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,33 +41,26 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.auth.CognitoUserInfo;
-import no.unit.nva.auth.FetchUserInfo;
 import nva.commons.apigateway.exceptions.ApiIoException;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.SingletonCollector;
 import nva.commons.core.StringUtils;
-import nva.commons.core.attempt.Failure;
-import nva.commons.core.exceptions.ExceptionUtils;
 import nva.commons.core.ioutils.IoUtils;
 import nva.commons.core.paths.UriWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("PMD.GodClass")
-public class RequestInfo {
+public final class RequestInfo {
 
     public static final String ERROR_FETCHING_COGNITO_INFO = "Could not fetch user information from Cognito:{}";
     private static final Logger logger = LoggerFactory.getLogger(RequestInfo.class);
     private static final ObjectMapper mapper = defaultRestObjectMapper;
-    private HttpClient httpClient;
-    private final Supplier<URI> cognitoUri;
-    private final Supplier<URI> e2eTestsUserInfoUri;
+    private static final String THIRD_PARTY_SCOPE_PREFIX = "https://api.nva.unit.no/scopes/third-party";
     @JsonProperty(HEADERS_FIELD)
     private Map<String, String> headers;
     @JsonProperty(PATH_FIELD)
@@ -98,12 +79,6 @@ public class RequestInfo {
     @JsonAnySetter
     private Map<String, Object> otherProperties;
 
-    public RequestInfo(HttpClient httpClient, Supplier<URI> cognitoUri, Supplier<URI> e2eTestsUserInfoUri) {
-        this.httpClient = httpClient;
-        this.cognitoUri = cognitoUri;
-        this.e2eTestsUserInfoUri = e2eTestsUserInfoUri;
-    }
-
     private RequestInfo() {
         this.headers = new HashMap<>();
         this.pathParameters = new HashMap<>();
@@ -111,20 +86,15 @@ public class RequestInfo {
         this.multiValueQueryStringParameters = new HashMap<>();
         this.otherProperties = new LinkedHashMap<>(); // ordinary HashMap and ConcurrentHashMap fail.
         this.requestContext = defaultRestObjectMapper.createObjectNode();
-        this.httpClient = HttpClient.newBuilder().build();
-        this.cognitoUri = DEFAULT_COGNITO_URI;
-        this.e2eTestsUserInfoUri = RequestInfoConstants.E2E_TESTING_USER_INFO_ENDPOINT;
     }
 
-    public static RequestInfo fromRequest(InputStream requestStream, HttpClient httpClient) throws ApiIoException {
+    public static RequestInfo fromRequest(InputStream requestStream) throws ApiIoException {
         String inputString = IoUtils.streamToString(requestStream);
-        return fromString(inputString, httpClient);
+        return fromString(inputString);
     }
 
-    public static RequestInfo fromString(String inputString, HttpClient httpClient) throws ApiIoException {
-        var requestInfo = new ApiMessageParser<>(mapper).getRequestInfo(inputString);
-        requestInfo.setHttpClient(httpClient);
-        return requestInfo;
+    public static RequestInfo fromString(String inputString) throws ApiIoException {
+        return new ApiMessageParser<>(mapper).getRequestInfo(inputString);
     }
 
     @JsonIgnore
@@ -210,11 +180,6 @@ public class RequestInfo {
         this.otherProperties = otherProperties;
     }
 
-    @JacocoGenerated
-    public void setHttpClient(HttpClient httpClient) {
-        this.httpClient = httpClient;
-    }
-
     public Map<String, String> getHeaders() {
         return headers;
     }
@@ -287,23 +252,26 @@ public class RequestInfo {
     }
 
     public boolean userIsAuthorized(AccessRight accessRight) {
-        return checkAuthorizationOnline(accessRight)
-               || checkAuthorizationFromContext(accessRight);
+        return checkAuthorizationFromContext(accessRight);
     }
 
     public List<AccessRight> getAccessRights() {
-        return extractAccessRightsForTests().or(this::fetchAccessRights).orElse(Collections.emptyList());
+        return fetchAccessRights().orElse(Collections.emptyList());
     }
 
     private Optional<List<AccessRight>> fetchAccessRights() {
         return fetchUserInfo().map(CognitoUserInfo::getAccessRights).map(this::parseAccessRights);
     }
 
+    private Optional<CognitoUserInfo> fetchUserInfo() {
+        return Optional.of(CognitoUserInfo.fromString(getRequestContext().at(CLAIMS_PATH).toString()));
+    }
+
     private List<AccessRight> parseAccessRights(String value) {
         return Arrays.stream(value.split(ELEMENTS_DELIMITER))
                    .filter(array -> !StringUtils.isEmpty(array))
                    .map(AccessRight::fromPersistedString)
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     @JacocoGenerated
@@ -322,22 +290,22 @@ public class RequestInfo {
 
     @JsonIgnore
     public String getUserName() throws UnauthorizedException {
-        return extractUserNameForTests().or(this::fetchUserName).orElseThrow(UnauthorizedException::new);
+        return fetchUserName().orElseThrow(UnauthorizedException::new);
     }
 
     @JsonIgnore
     public ViewingScope getViewingScope() throws UnauthorizedException {
-        return extractViewingScopeForTests().or(this::fetchViewingScope).orElseThrow(UnauthorizedException::new);
+        return fetchViewingScope().orElseThrow(UnauthorizedException::new);
     }
 
     @JsonIgnore
     public Optional<String> getFeideId() {
-        return extractFeideIdForTests().or(this::fetchFeideId);
+        return fetchFeideId();
     }
 
     @JsonIgnore
     public Optional<URI> getTopLevelOrgCristinId() {
-        return extractTopLevelOrgForTests().or(this::fetchTopLevelOrgCristinId);
+        return fetchTopLevelOrgCristinId();
     }
 
     @JsonIgnore
@@ -348,25 +316,22 @@ public class RequestInfo {
     @JsonIgnore
     public URI getCurrentCustomer() throws UnauthorizedException {
         return fetchCustomerId().or(this::fetchCustomerIdFromContext)
-                   .or(this::extractCustomerIdForTests)
                    .orElseThrow(UnauthorizedException::new);
     }
 
     @JsonIgnore
     public URI getPersonCristinId() throws UnauthorizedException {
-        return extractPersonCristinIdForTests().or(this::fetchPersonCristinId)
-                   .orElseThrow(UnauthorizedException::new);
+        return fetchPersonCristinId().orElseThrow(UnauthorizedException::new);
     }
 
     @JsonIgnore
     public URI getPersonAffiliation() throws UnauthorizedException {
-        return extractPersonAffiliationForTests().or(this::fetchPersonAffiliation)
-                   .orElseThrow(UnauthorizedException::new);
+        return fetchPersonAffiliation().orElseThrow(UnauthorizedException::new);
     }
 
     @JsonIgnore
     public String getPersonNin() {
-        return extractPersonNinForTests().or(this::fetchPersonNin).orElseThrow(IllegalStateException::new);
+        return fetchPersonNin().orElseThrow(IllegalStateException::new);
     }
 
     public boolean clientIsInternalBackend() {
@@ -375,17 +340,16 @@ public class RequestInfo {
     }
 
     public boolean clientIsThirdParty() {
-        return getRequestContextParameterOpt(ISS).map(
-            value -> value.equals(EXTERNAL_USER_POOL_URI.get())
-        ).orElse(false);
+        return getRequestContextParameterOpt(SCOPES_CLAIM)
+                   .map(string ->
+                            Arrays.stream(string.split(","))
+                                .anyMatch(value -> value.startsWith(
+                                    THIRD_PARTY_SCOPE_PREFIX)))
+                   .orElse(false);
     }
 
     private Optional<String> fetchFeideId() {
         return fetchUserInfo().map(CognitoUserInfo::getFeideId);
-    }
-
-    private Optional<String> extractFeideIdForTests() {
-        return getRequestContextParameterOpt(FEIDE_ID);
     }
 
     private Optional<URI> fetchCustomerIdFromContext() {
@@ -397,34 +361,8 @@ public class RequestInfo {
                    .toOptional();
     }
 
-    private Optional<URI> extractCustomerIdForTests() {
-        return getRequestContextParameterOpt(CUSTOMER_ID).map(URI::create);
-    }
-
-    private Optional<URI> extractTopLevelOrgForTests() {
-        return getRequestContextParameterOpt(TOP_LEVEL_ORG_CRISTIN_ID).map(URI::create);
-    }
-
     private Optional<URI> fetchTopLevelOrgCristinId() {
         return fetchUserInfo().map(CognitoUserInfo::getTopOrgCristinId);
-    }
-
-    private void logOnlineFetchResult(Failure<CognitoUserInfo> fail) {
-        logger.warn(ERROR_FETCHING_COGNITO_INFO, ExceptionUtils.stackTraceInSingleLine(fail.getException()));
-    }
-
-    private Optional<ViewingScope> extractViewingScopeForTests() {
-        var includedString = getRequestContextParameterOpt(VIEWING_SCOPE_INCLUDED);
-        var excludedString = getRequestContextParameterOpt(VIEWING_SCOPE_EXCLUDED);
-
-        if (includedString.isEmpty() || excludedString.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(ViewingScope.from(includedString.get(), excludedString.get()));
-    }
-
-    private Optional<String> extractUserNameForTests() {
-        return getRequestContextParameterOpt(USER_NAME);
     }
 
     private Optional<String> fetchUserName() {
@@ -436,24 +374,12 @@ public class RequestInfo {
             userInfo -> ViewingScope.from(userInfo.getViewingScopeIncluded(), userInfo.getViewingScopeExcluded()));
     }
 
-    private Optional<URI> extractPersonCristinIdForTests() {
-        return getRequestContextParameterOpt(PERSON_CRISTIN_ID).map(URI::create);
-    }
-
-    private Optional<URI> extractPersonAffiliationForTests() {
-        return getRequestContextParameterOpt(PERSON_AFFILIATION).map(URI::create);
-    }
-
     private Optional<URI> fetchPersonCristinId() {
         return fetchUserInfo().map(CognitoUserInfo::getPersonCristinId);
     }
 
     private Optional<URI> fetchPersonAffiliation() {
         return fetchUserInfo().map(CognitoUserInfo::getPersonAffiliation);
-    }
-
-    private Optional<String> extractPersonNinForTests() {
-        return getRequestContextParameterOpt(PERSON_NIN);
     }
 
     private Optional<String> fetchPersonNin() {
@@ -476,45 +402,6 @@ public class RequestInfo {
 
     private Stream<AccessRightEntry> fetchAvailableAccessRightsFromContext() {
         return getRequestContextParameterOpt(PERSON_GROUPS).stream().flatMap(AccessRightEntry::fromCsv);
-    }
-
-    private Boolean checkAuthorizationOnline(AccessRight accessRight) {
-        var accessRightAtCustomer = fetchCustomerId().map(
-            customer -> new AccessRightEntry(accessRight, customer));
-
-        var availableRights = fetchAvailableRights();
-        return accessRightAtCustomer.map(availableRights::contains).orElse(false);
-    }
-
-    private List<AccessRightEntry> fetchAvailableRights() {
-        var userInfo = fetchUserInfo();
-        return userInfo
-                   .map(CognitoUserInfo::getAccessRights)
-                   .map(accessRightEntryStr -> AccessRightEntry.fromCsvForCustomer(accessRightEntryStr, userInfo.get()
-                                                                                                            .getCurrentCustomer()))
-                   .map(stream -> stream.collect(Collectors.toList()))
-                   .orElseGet(Collections::emptyList);
-    }
-
-    private Optional<List<AccessRight>> extractAccessRightsForTests() {
-        return getRequestContextParameterOpt(PERSON_GROUPS)
-                   .map(AccessRightEntry::fromCsv)
-                   .map(stream -> stream.map(AccessRightEntry::getAccessRight))
-                   .map(stream -> stream.collect(Collectors.toList()));
-    }
-
-    private Optional<CognitoUserInfo> fetchUserInfo() {
-        return attempt(() -> fetchUserInfo(cognitoUri)).or(() -> fetchUserInfo(e2eTestsUserInfoUri))
-                   .toOptional(this::logOnlineFetchResult);
-    }
-
-    private CognitoUserInfo fetchUserInfo(Supplier<URI> cognitoUri) {
-        var userInfo = new FetchUserInfo(httpClient, cognitoUri, extractAuthorizationHeader());
-        return userInfo.fetch();
-    }
-
-    private String extractAuthorizationHeader() {
-        return this.getHeader(HttpHeaders.AUTHORIZATION);
     }
 
     private Optional<URI> fetchCustomerId() {

--- a/apigateway/src/main/java/nva/commons/apigateway/RequestInfo.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/RequestInfo.java
@@ -256,18 +256,18 @@ public final class RequestInfo {
         return false;
     }
 
-    public List<AccessRight> getAccessRights() throws UnauthorizedException {
+    public List<AccessRight> getAccessRights() {
         return fetchAccessRights().orElse(Collections.emptyList());
     }
 
-    private Optional<List<AccessRight>> fetchAccessRights() throws UnauthorizedException {
+    private Optional<List<AccessRight>> fetchAccessRights() {
         return fetchUserInfo().map(CognitoUserInfo::getAccessRights).map(this::parseAccessRights);
     }
 
-    private Optional<CognitoUserInfo> fetchUserInfo() throws UnauthorizedException {
+    private Optional<CognitoUserInfo> fetchUserInfo() {
         var pointer = getRequestContext().at(CLAIMS_PATH);
         if (pointer.isMissingNode()) {
-            throw new UnauthorizedException();
+            return Optional.empty();
         }
         return Optional.of(CognitoUserInfo.fromString(pointer.toString()));
     }
@@ -304,12 +304,12 @@ public final class RequestInfo {
     }
 
     @JsonIgnore
-    public Optional<String> getFeideId() throws UnauthorizedException {
+    public Optional<String> getFeideId()  {
         return fetchFeideId();
     }
 
     @JsonIgnore
-    public Optional<URI> getTopLevelOrgCristinId() throws UnauthorizedException {
+    public Optional<URI> getTopLevelOrgCristinId() {
         return fetchTopLevelOrgCristinId();
     }
 
@@ -339,7 +339,7 @@ public final class RequestInfo {
     }
 
     @JsonIgnore
-    public String getPersonNin() throws UnauthorizedException {
+    public String getPersonNin() {
         return fetchPersonNin().orElseThrow(IllegalStateException::new);
     }
 
@@ -357,40 +357,40 @@ public final class RequestInfo {
                    .orElse(false);
     }
 
-    private Optional<String> fetchFeideId() throws UnauthorizedException {
+    private Optional<String> fetchFeideId() {
         return fetchUserInfo().map(CognitoUserInfo::getFeideId);
     }
 
-    private Optional<URI> fetchTopLevelOrgCristinId() throws UnauthorizedException {
+    private Optional<URI> fetchTopLevelOrgCristinId() {
         return fetchUserInfo().map(CognitoUserInfo::getTopOrgCristinId);
     }
 
-    private Optional<String> fetchUserName() throws UnauthorizedException {
+    private Optional<String> fetchUserName() {
         return fetchUserInfo().map(CognitoUserInfo::getUserName);
     }
 
-    private Optional<ViewingScope> fetchViewingScope() throws UnauthorizedException {
+    private Optional<ViewingScope> fetchViewingScope(){
         return fetchUserInfo().map(
             userInfo -> ViewingScope.from(userInfo.getViewingScopeIncluded(), userInfo.getViewingScopeExcluded()));
     }
 
-    private Optional<URI> fetchPersonCristinId() throws UnauthorizedException {
+    private Optional<URI> fetchPersonCristinId() {
         return fetchUserInfo().map(CognitoUserInfo::getPersonCristinId);
     }
 
-    private Optional<URI> fetchPersonAffiliation() throws UnauthorizedException {
+    private Optional<URI> fetchPersonAffiliation() {
         return fetchUserInfo().map(CognitoUserInfo::getPersonAffiliation);
     }
 
-    private Optional<String> fetchPersonNin() throws UnauthorizedException {
+    private Optional<String> fetchPersonNin() {
         return fetchUserInfo().map(CognitoUserInfo::getPersonNin);
     }
 
-    private Optional<URI> fetchCustomerId() throws UnauthorizedException {
+    private Optional<URI> fetchCustomerId() {
         return fetchUserInfo().map(CognitoUserInfo::getCurrentCustomer);
     }
 
-    private Optional<List<URI>> fetchAllowedCustomers() throws UnauthorizedException {
+    private Optional<List<URI>> fetchAllowedCustomers() {
         return fetchUserInfo().map(CognitoUserInfo::getAllowedCustomers)
                    .map(customers -> customers.split(",")) // Split the string by commas
                    .map(Arrays::stream)

--- a/apigateway/src/main/java/nva/commons/apigateway/RequestInfo.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/RequestInfo.java
@@ -266,9 +266,8 @@ public final class RequestInfo {
     }
 
     private Optional<CognitoUserInfo> fetchUserInfo() {
-        var pointer = getRequestContext().at(CLAIMS_PATH);
-
-        return pointer.isMissingNode() ? Optional.empty() : Optional.of(CognitoUserInfo.fromString(pointer.toString()));
+        var claims = getRequestContext().at(CLAIMS_PATH);
+        return claims.isObject() ? Optional.of(CognitoUserInfo.fromString(claims.toString())) : Optional.empty();
     }
 
     private List<AccessRight> parseAccessRights(String value) {

--- a/apigateway/src/main/java/nva/commons/apigateway/RequestInfoConstants.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/RequestInfoConstants.java
@@ -1,31 +1,11 @@
 package nva.commons.apigateway;
 
-import static no.unit.nva.auth.CognitoUserInfo.PERSON_AFFILIATION_CLAIM;
-import static no.unit.nva.auth.CognitoUserInfo.PERSON_CRISTIN_ID_CLAIM;
-import static no.unit.nva.auth.CognitoUserInfo.PERSON_NIN_CLAIM;
-import static no.unit.nva.auth.CognitoUserInfo.SELECTED_CUSTOMER_CLAIM;
-import static no.unit.nva.auth.CognitoUserInfo.TOP_LEVEL_ORG_CRISTIN_ID_CLAIM;
-import static no.unit.nva.auth.CognitoUserInfo.USER_NAME_CLAIM;
-import static no.unit.nva.auth.CognitoUserInfo.VIEWING_SCOPE_EXCLUDED_CLAIM;
-import static no.unit.nva.auth.CognitoUserInfo.VIEWING_SCOPE_INCLUDED_CLAIM;
-import static no.unit.nva.auth.OAuthConstants.OAUTH_USER_INFO;
 import com.fasterxml.jackson.core.JsonPointer;
-import java.net.URI;
-import java.util.function.Supplier;
-import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
-import nva.commons.core.paths.UriWrapper;
 
 @JacocoGenerated
 public final class RequestInfoConstants {
 
-    public static final Environment ENVIRONMENT = new Environment();
-    public static final Supplier<URI> DEFAULT_COGNITO_URI =
-        RequestInfoConstants::lazyInitializationForDefaultCognitoUri;
-    public static final Supplier<String> EXTERNAL_USER_POOL_URI =
-        RequestInfoConstants::lazyInitializationForDefaultExternalUserPoolUri;
-    public static final String IDENTITY_SERVICE_PATH = "users-roles";
-    public static final String IDENTITY_SERVICE_USER_INFO_PATH = "userinfo";
     public static final String QUERY_STRING_PARAMETERS_FIELD = "queryStringParameters";
     public static final String MULTI_VALUE_QUERY_STRING_PARAMETERS_FIELD = "multiValueQueryStringParameters";
     public static final String PATH_PARAMETERS_FIELD = "pathParameters";
@@ -39,44 +19,19 @@ public final class RequestInfoConstants {
     public static final String MISSING_FROM_PATH_PARAMETERS = "Missing from pathParameters: ";
     public static final String MISSING_FROM_REQUEST_CONTEXT = "Missing from requestContext: ";
     public static final String DOMAIN_NAME_FIELD = "domainName";
-    public static final String PERSON_GROUPS_CLAIM = "cognito:groups";
     public static final String AUTHORIZATION_FAILURE_WARNING = "Missing customerId or required access right";
     public static final String BACKEND_SCOPE_AS_DEFINED_IN_IDENTITY_SERVICE = "https://api.nva.unit.no/scopes/backend";
     public static final String SCOPE = "scope";
-    public static final String FEIDE_ID_CLAIM = "custom:feideId";
     public static final String CLIENT_ID_CLAIM = "client_id";
-    public static final String ISS_CLAIM = "iss";
     public static final String CLAIMS_PATH = "/authorizer/claims";
-    public static final JsonPointer PERSON_GROUPS = claimToJsonPointer(PERSON_GROUPS_CLAIM);
-    public static final JsonPointer USER_NAME = claimToJsonPointer(USER_NAME_CLAIM);
-    public static final JsonPointer TOP_LEVEL_ORG_CRISTIN_ID = claimToJsonPointer(TOP_LEVEL_ORG_CRISTIN_ID_CLAIM);
-    public static final JsonPointer PERSON_CRISTIN_ID = claimToJsonPointer(PERSON_CRISTIN_ID_CLAIM);
-    public static final JsonPointer PERSON_AFFILIATION = claimToJsonPointer(PERSON_AFFILIATION_CLAIM);
+
     public static final JsonPointer SCOPES_CLAIM = claimToJsonPointer(SCOPE);
-    public static final JsonPointer PERSON_NIN = claimToJsonPointer(PERSON_NIN_CLAIM);
-    public static final JsonPointer FEIDE_ID = claimToJsonPointer(FEIDE_ID_CLAIM);
     public static final JsonPointer CLIENT_ID = claimToJsonPointer(CLIENT_ID_CLAIM);
-    public static final JsonPointer CUSTOMER_ID = claimToJsonPointer(SELECTED_CUSTOMER_CLAIM);
-    public static final JsonPointer ISS = claimToJsonPointer(ISS_CLAIM);
-    public static final JsonPointer VIEWING_SCOPE_INCLUDED = claimToJsonPointer(VIEWING_SCOPE_INCLUDED_CLAIM);
-    public static final JsonPointer VIEWING_SCOPE_EXCLUDED = claimToJsonPointer(VIEWING_SCOPE_EXCLUDED_CLAIM);
 
     private RequestInfoConstants() {
 
     }
 
-    private static URI lazyInitializationForDefaultCognitoUri() {
-        String cognitoHost = ENVIRONMENT.readEnv("COGNITO_HOST");
-        return createUri(cognitoHost, OAUTH_USER_INFO);
-    }
-
-    private static String lazyInitializationForDefaultExternalUserPoolUri() {
-        return ENVIRONMENT.readEnv("EXTERNAL_USER_POOL_URI");
-    }
-
-    private static URI createUri(String cognitoHost, String... path) {
-        return UriWrapper.fromHost(cognitoHost).addChild(path).getUri();
-    }
 
     private static JsonPointer claimToJsonPointer(String claim) {
         return JsonPointer.compile(CLAIMS_PATH + "/" + claim);

--- a/apigateway/src/main/java/nva/commons/apigateway/RequestInfoConstants.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/RequestInfoConstants.java
@@ -1,9 +1,9 @@
 package nva.commons.apigateway;
 
-import static no.unit.nva.auth.CognitoUserInfo.CUSTOMER_ID_CLAIM;
 import static no.unit.nva.auth.CognitoUserInfo.PERSON_AFFILIATION_CLAIM;
 import static no.unit.nva.auth.CognitoUserInfo.PERSON_CRISTIN_ID_CLAIM;
 import static no.unit.nva.auth.CognitoUserInfo.PERSON_NIN_CLAIM;
+import static no.unit.nva.auth.CognitoUserInfo.SELECTED_CUSTOMER_CLAIM;
 import static no.unit.nva.auth.CognitoUserInfo.TOP_LEVEL_ORG_CRISTIN_ID_CLAIM;
 import static no.unit.nva.auth.CognitoUserInfo.USER_NAME_CLAIM;
 import static no.unit.nva.auth.CognitoUserInfo.VIEWING_SCOPE_EXCLUDED_CLAIM;
@@ -26,8 +26,6 @@ public final class RequestInfoConstants {
         RequestInfoConstants::lazyInitializationForDefaultExternalUserPoolUri;
     public static final String IDENTITY_SERVICE_PATH = "users-roles";
     public static final String IDENTITY_SERVICE_USER_INFO_PATH = "userinfo";
-    public static final Supplier<URI> E2E_TESTING_USER_INFO_ENDPOINT =
-        RequestInfoConstants::lazyInitializationForE2EUserInfoEndpoint;
     public static final String QUERY_STRING_PARAMETERS_FIELD = "queryStringParameters";
     public static final String MULTI_VALUE_QUERY_STRING_PARAMETERS_FIELD = "multiValueQueryStringParameters";
     public static final String PATH_PARAMETERS_FIELD = "pathParameters";
@@ -48,7 +46,7 @@ public final class RequestInfoConstants {
     public static final String FEIDE_ID_CLAIM = "custom:feideId";
     public static final String CLIENT_ID_CLAIM = "client_id";
     public static final String ISS_CLAIM = "iss";
-    private static final String CLAIMS_PATH = "/authorizer/claims/";
+    public static final String CLAIMS_PATH = "/authorizer/claims";
     public static final JsonPointer PERSON_GROUPS = claimToJsonPointer(PERSON_GROUPS_CLAIM);
     public static final JsonPointer USER_NAME = claimToJsonPointer(USER_NAME_CLAIM);
     public static final JsonPointer TOP_LEVEL_ORG_CRISTIN_ID = claimToJsonPointer(TOP_LEVEL_ORG_CRISTIN_ID_CLAIM);
@@ -58,21 +56,13 @@ public final class RequestInfoConstants {
     public static final JsonPointer PERSON_NIN = claimToJsonPointer(PERSON_NIN_CLAIM);
     public static final JsonPointer FEIDE_ID = claimToJsonPointer(FEIDE_ID_CLAIM);
     public static final JsonPointer CLIENT_ID = claimToJsonPointer(CLIENT_ID_CLAIM);
-    public static final JsonPointer CUSTOMER_ID = claimToJsonPointer(CUSTOMER_ID_CLAIM);
+    public static final JsonPointer CUSTOMER_ID = claimToJsonPointer(SELECTED_CUSTOMER_CLAIM);
     public static final JsonPointer ISS = claimToJsonPointer(ISS_CLAIM);
     public static final JsonPointer VIEWING_SCOPE_INCLUDED = claimToJsonPointer(VIEWING_SCOPE_INCLUDED_CLAIM);
     public static final JsonPointer VIEWING_SCOPE_EXCLUDED = claimToJsonPointer(VIEWING_SCOPE_EXCLUDED_CLAIM);
 
     private RequestInfoConstants() {
 
-    }
-
-    private static URI lazyInitializationForE2EUserInfoEndpoint() {
-        var apiHost = ENVIRONMENT.readEnv("API_HOST");
-        return UriWrapper.fromHost(apiHost)
-            .addChild(IDENTITY_SERVICE_PATH)
-            .addChild(IDENTITY_SERVICE_USER_INFO_PATH)
-            .getUri();
     }
 
     private static URI lazyInitializationForDefaultCognitoUri() {
@@ -89,6 +79,6 @@ public final class RequestInfoConstants {
     }
 
     private static JsonPointer claimToJsonPointer(String claim) {
-        return JsonPointer.compile(CLAIMS_PATH + claim);
+        return JsonPointer.compile(CLAIMS_PATH + "/" + claim);
     }
 }

--- a/apigateway/src/main/java/nva/commons/apigateway/RestRequestHandler.java
+++ b/apigateway/src/main/java/nva/commons/apigateway/RestRequestHandler.java
@@ -11,7 +11,6 @@ import com.google.common.net.MediaType;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.http.HttpClient;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -46,7 +45,6 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
     private final transient Class<I> iclass;
     private final transient ApiMessageParser<I> inputParser;
     protected final ObjectMapper objectMapper;
-    private final HttpClient httpClient;
 
     protected transient OutputStream outputStream;
     protected transient String allowedOrigin;
@@ -134,13 +132,11 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
      * @param iclass      The class object of the input class.
      * @param environment the Environment from where the handler will read ENV variables.
      */
-    public RestRequestHandler(Class<I> iclass, Environment environment, ObjectMapper objectMapper,
-                              HttpClient httpClient) {
+    public RestRequestHandler(Class<I> iclass, Environment environment, ObjectMapper objectMapper) {
         this.iclass = iclass;
         this.environment = environment;
         this.inputParser = new ApiMessageParser<>(objectMapper);
         this.objectMapper = objectMapper;
-        this.httpClient = httpClient;
     }
 
     @Override
@@ -153,8 +149,7 @@ public abstract class RestRequestHandler<I, O> implements RequestStreamHandler {
             inputObject = attempt(() -> parseInput(inputString))
                               .orElseThrow(this::parsingExceptionToBadRequestException);
 
-            RequestInfo requestInfo = RequestInfo.fromString(inputString, httpClient);
-            requestInfo.setHttpClient(httpClient);
+            RequestInfo requestInfo = RequestInfo.fromString(inputString);
             setAllowedOrigin(requestInfo);
 
             validateRequest(inputObject, requestInfo, context);

--- a/apigateway/src/test/java/nva/commons/apigateway/AccessRightEntryTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/AccessRightEntryTest.java
@@ -1,9 +1,9 @@
 package nva.commons.apigateway;
 
 import static no.unit.nva.testutils.RandomDataGenerator.randomAccessRight;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import org.junit.jupiter.api.Test;
@@ -11,11 +11,27 @@ import org.junit.jupiter.api.Test;
 class AccessRightEntryTest {
 
     @Test
-    public void toStringReturnsTheSameStringForEquivalentObjects() {
+    void toStringReturnsTheSameStringForEquivalentObjects() {
         var accessRight = randomAccessRight();
         var customerId = randomUri();
         var group1 = new AccessRightEntry(accessRight, customerId);
         var group2 = new AccessRightEntry(accessRight, customerId);
         assertThat(group1.toString(), is(equalTo(group2.toString())));
+    }
+
+    @Test
+    void fromCvs() {
+        var accessRight1 = randomAccessRight();
+        var customerId1 = randomUri();
+        var accessRight2 = randomAccessRight();
+        var customerId2 = randomUri();
+        var csv = accessRight1.toPersistedString() + "@" + customerId1 + ","
+                  + accessRight2.toPersistedString() + "@" + customerId2;
+        var group = AccessRightEntry.fromCsv(csv).toList();
+
+        assertThat(group, containsInAnyOrder(
+            new AccessRightEntry(accessRight1, customerId1),
+            new AccessRightEntry(accessRight2, customerId2)
+        ));
     }
 }

--- a/apigateway/src/test/java/nva/commons/apigateway/AccessRightEntryTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/AccessRightEntryTest.java
@@ -20,7 +20,7 @@ class AccessRightEntryTest {
     }
 
     @Test
-    void fromCvs() {
+    void fromCsv() {
         var accessRight1 = randomAccessRight();
         var customerId1 = randomUri();
         var accessRight2 = randomAccessRight();

--- a/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/ApiGatewayHandlerTest.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
-import java.net.http.HttpClient;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +84,6 @@ class ApiGatewayHandlerTest {
     private static final String PATH = "path1/path2/path3";
     private Context context;
     private Handler handler;
-    private HttpClient httpClient;
     private Environment environment;
 
     public static Stream<String> mediaTypeProvider() {
@@ -96,10 +94,9 @@ class ApiGatewayHandlerTest {
     @BeforeEach
     public void setup() {
         context = new FakeContext();
-        httpClient = mock(HttpClient.class);
         environment = mock(Environment.class);
         when(environment.readEnv("ALLOWED_ORIGIN")).thenReturn("*");
-        handler = new Handler(environment, httpClient);
+        handler = new Handler(environment);
     }
 
     @Test
@@ -493,7 +490,7 @@ class ApiGatewayHandlerTest {
     }
 
     private RawStringResponseHandler getRawStringResponseHandler() {
-        return new RawStringResponseHandler(environment, httpClient);
+        return new RawStringResponseHandler(environment);
     }
 
     @Test

--- a/apigateway/src/test/java/nva/commons/apigateway/RequestInfoTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/RequestInfoTest.java
@@ -214,16 +214,14 @@ class RequestInfoTest {
     @Test
     void shouldReturnThatUserDoesNotHaveAccessRightForSpecificCustomerWhenCognitoDoesNotHaveRespectiveAccessRight() {
         var usersCustomer = randomUri();
-        var accessRightsForCustomer = Set.of(new AccessRightEntry(MANAGE_PUBLISHING_REQUESTS, usersCustomer)
-                                                 .toString());
+        var accessRights = Set.of(MANAGE_PUBLISHING_REQUESTS.toPersistedString());
         var cognitoUserEntry = CognitoUserInfo.builder()
                                    .withCurrentCustomer(usersCustomer)
-                                   .withAccessRights(accessRightsForCustomer)
+                                   .withAccessRights(accessRights)
                                    .build();
 
         var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
-        var requestedAccessRight = MANAGE_DOI;
-        var userIsAuthorized = requestInfo.userIsAuthorized(requestedAccessRight);
+        var userIsAuthorized = requestInfo.userIsAuthorized(MANAGE_DOI);
         assertThat(userIsAuthorized, is(false));
     }
 
@@ -723,10 +721,10 @@ class RequestInfoTest {
         return getRequestInfo(request);
     }
 
-    private CognitoUserInfo createCognitoUserEntry(URI usersCustomer, Set<String> accessRightsForCustomer) {
+    private CognitoUserInfo createCognitoUserEntry(URI usersCustomer, Set<String> accessRights) {
         return CognitoUserInfo.builder()
                    .withCurrentCustomer(usersCustomer)
-                   .withAccessRights(accessRightsForCustomer)
+                   .withAccessRights(accessRights)
                    .build();
     }
 

--- a/apigateway/src/test/java/nva/commons/apigateway/RequestInfoTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/RequestInfoTest.java
@@ -242,8 +242,8 @@ class RequestInfoTest {
     @Test
     void shouldReturnThatUserIsAuthorizedWhenRequestInfoContainsACustomerIdAndTheRequestedAccessRight() {
         var usersCustomer = randomUri();
-        var usersAccessRights = Set.of(randomAccessRight().toPersistedString(),
-                                       randomAccessRight().toPersistedString());
+        var usersAccessRights = Set.of(MANAGE_DEGREE.toPersistedString(),
+                                       MANAGE_IMPORT.toPersistedString());
         var cognitoUserEntry = CognitoUserInfo.builder()
                                    .withCurrentCustomer(usersCustomer)
                                    .withAccessRights(usersAccessRights)
@@ -494,7 +494,7 @@ class RequestInfoTest {
     }
 
     @Test
-    void shouldReturnTopLevelOrgCristinIdWhenCurrentCustomerHasBeenSelectedForPerson() throws UnauthorizedException {
+    void shouldReturnTopLevelOrgCristinIdWhenCurrentCustomerHasBeenSelectedForPerson() {
         var topOrgCristinId = randomUri();
         var cognitoUserEntry = CognitoUserInfo.builder().withTopOrgCristinId(topOrgCristinId).build();
         var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
@@ -503,7 +503,7 @@ class RequestInfoTest {
 
     @Test
     void shouldReturnTopLevelOrgCristinIdWhenRequestsAuthorizerNodeContainsCorrespondingClaim()
-        throws JsonProcessingException, ApiIoException, UnauthorizedException {
+        throws JsonProcessingException, ApiIoException {
         var topOrgCristinId = randomUri();
         var requestInfo = requestInfoWithAuthorizerClaim(topOrgCristinId.toString());
         assertThat(requestInfo.getTopLevelOrgCristinId().orElseThrow(), is(equalTo(topOrgCristinId)));
@@ -540,7 +540,7 @@ class RequestInfoTest {
     }
 
     @Test
-    void shouldReturnPersonNinFromCognitoWhenUserHasPersonNinInClaimAndIsNotOffline() throws UnauthorizedException {
+    void shouldReturnPersonNinFromCognitoWhenUserHasPersonNinInClaimAndIsNotOffline() {
         var expectedPersonNin = randomString();
         var cognitoUserEntry = CognitoUserInfo.builder().withPersonNin(expectedPersonNin).build();
         var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
@@ -549,7 +549,7 @@ class RequestInfoTest {
     }
 
     @Test
-    void shouldReturnPersonNinWhenUserHasPersonNinInClaimAvailableOffline() throws UnauthorizedException {
+    void shouldReturnPersonNinWhenUserHasPersonNinInClaimAvailableOffline() {
         var cognitoUserEntry = CognitoUserInfo.builder().withPersonNin(randomString()).build();
         var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var expectedPersonNinDifferentFromCognito = randomString();
@@ -560,7 +560,7 @@ class RequestInfoTest {
 
     @Test
     void shouldReturnPersonNinFromFeideNinClaimWhenOnlyFeideNinIsPresentInCognito()
-        throws JsonProcessingException, UnauthorizedException {
+        throws JsonProcessingException {
         var expectedPersonFeideNin = randomString();
         var claims = dtoObjectMapper.createObjectNode();
         claims.put(CognitoUserInfo.PERSON_FEIDE_NIN_CLAIM, expectedPersonFeideNin);
@@ -573,7 +573,7 @@ class RequestInfoTest {
     }
 
     @Test
-    void shouldReturnFeideIdFromCognitoWhenUserHasFeideIdInClaimAndIsNotOffline() throws UnauthorizedException {
+    void shouldReturnFeideIdFromCognitoWhenUserHasFeideIdInClaimAndIsNotOffline() {
         var expectedFeideId = randomString();
         var cognitoUserEntry = CognitoUserInfo.builder().withFeideId(expectedFeideId).build();
         var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
@@ -584,7 +584,7 @@ class RequestInfoTest {
     }
 
     @Test
-    void shouldReturnFeideIdWhenUserHasFeideIdInClaimAvailableOffline() throws UnauthorizedException {
+    void shouldReturnFeideIdWhenUserHasFeideIdInClaimAvailableOffline() {
         var cognitoUserEntry = CognitoUserInfo.builder().withFeideId(randomString()).build();
         var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var expectedFeideIdDifferentFromCognito = randomString();
@@ -597,7 +597,7 @@ class RequestInfoTest {
 
     @Test
     void shouldReturnFeideIdFromFeideClaimWhenOnlyFeideIdIsPresentInCognito()
-        throws JsonProcessingException, UnauthorizedException {
+        throws JsonProcessingException {
         var expectedFeideId = randomString();
         var claims = dtoObjectMapper.createObjectNode();
         claims.put(CognitoUserInfo.PERSON_FEIDE_ID_CLAIM, expectedFeideId);
@@ -611,7 +611,7 @@ class RequestInfoTest {
     }
 
     @Test
-    void shouldReturnAccessRightsWhenOnlyInCognito() throws JsonProcessingException, UnauthorizedException {
+    void shouldReturnAccessRightsWhenOnlyInCognito() throws JsonProcessingException {
         var accessRights = randomAccessRights();
         var accessRightsString = accessRights.stream()
                                      .map(AccessRight::toPersistedString)
@@ -628,7 +628,7 @@ class RequestInfoTest {
     }
 
     @Test
-    void shouldReturnOptionalEmptyWhenUserDoesNotHaveFeideId() throws UnauthorizedException {
+    void shouldReturnOptionalEmptyWhenUserDoesNotHaveFeideId() {
         var cognitoUserEntryWithoutFeideId = CognitoUserInfo.builder().build();
         var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntryWithoutFeideId);
 
@@ -645,7 +645,7 @@ class RequestInfoTest {
     }
 
     @Test
-    void shouldReturnEmptyListWhenAccessRightsCognitoStringIsEmpty() throws UnauthorizedException {
+    void shouldReturnEmptyListWhenAccessRightsCognitoStringIsEmpty() {
         var cognitoUserEntry = CognitoUserInfo.builder().build();
         var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var accessRights = requestInfo.getAccessRights();

--- a/apigateway/src/test/java/nva/commons/apigateway/RequestInfoTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/RequestInfoTest.java
@@ -1,6 +1,6 @@
 package nva.commons.apigateway;
 
-import static no.unit.nva.auth.OAuthConstants.OAUTH_USER_INFO;
+import static java.util.Objects.nonNull;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomAccessRight;
@@ -9,13 +9,11 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE;
 import static nva.commons.apigateway.AccessRight.MANAGE_DOI;
 import static nva.commons.apigateway.AccessRight.MANAGE_IMPORT;
-import static nva.commons.apigateway.AccessRight.MANAGE_NVI;
 import static nva.commons.apigateway.AccessRight.MANAGE_PUBLISHING_REQUESTS;
-import static nva.commons.apigateway.RequestInfo.ERROR_FETCHING_COGNITO_INFO;
 import static nva.commons.apigateway.RequestInfoConstants.AUTHORIZATION_FAILURE_WARNING;
 import static nva.commons.apigateway.RequestInfoConstants.BACKEND_SCOPE_AS_DEFINED_IN_IDENTITY_SERVICE;
+import static nva.commons.apigateway.RequestInfoConstants.PERSON_GROUPS_CLAIM;
 import static nva.commons.apigateway.RequestInfoConstants.REQUEST_CONTEXT_FIELD;
-import static nva.commons.apigateway.RequestInfoConstants.VIEWING_SCOPE_INCLUDED;
 import static nva.commons.apigateway.RestConfig.defaultRestObjectMapper;
 import static nva.commons.core.paths.UriWrapper.HTTPS;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,12 +34,12 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.net.HttpHeaders;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,12 +47,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.auth.CognitoUserInfo;
-import no.unit.nva.stubs.FakeAuthServer;
-import no.unit.nva.stubs.WiremockHttpClient;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import no.unit.nva.testutils.RandomDataGenerator;
 import nva.commons.apigateway.exceptions.ApiIoException;
@@ -62,9 +57,6 @@ import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.ioutils.IoUtils;
 import nva.commons.core.paths.UriWrapper;
 import nva.commons.logutils.LogUtils;
-import org.hamcrest.core.IsIterableContaining;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -88,36 +80,18 @@ class RequestInfoTest {
     public static final String PATH_FOUND_IN_RESOURCE_FILE = "my/path";
     public static final Map<String, String> QUERY_PARAMS_FOUND_IN_RESOURCE_FILE;
     public static final String AT = "@";
-    public static final String LOG_STRING_INTERPOLATION = "{}";
-    public static final String EMPTY_STRING = "";
     private static final String API_GATEWAY_MESSAGES_FOLDER = "apiGatewayMessages";
     private static final Path NULL_VALUES_FOR_MAPS = Path.of(API_GATEWAY_MESSAGES_FOLDER, "mapParametersAreNull.json");
     private static final Path MISSING_MAP_VALUES = Path.of(API_GATEWAY_MESSAGES_FOLDER, "missingRequestInfo.json");
     private static final Path AWS_SAMPLE_PROXY_EVENT = Path.of(API_GATEWAY_MESSAGES_FOLDER, "awsSampleProxyEvent.json");
     private static final String HARDCODED_AUTH_HEADER = "Bearer THE_ACCESS_TOKEN";
     public static final String EXTERNAL_USER_POOL_URL = "https//user-pool.example.com/123";
+    private static final String THIRD_PARTY_PUBLICATION_UPSERT = "https://api.nva.unit.no/scopes/third-party/publication-upsert";
 
     static {
         QUERY_PARAMS_FOUND_IN_RESOURCE_FILE = new TreeMap<>();
         QUERY_PARAMS_FOUND_IN_RESOURCE_FILE.put("parameter1", "value1");
         QUERY_PARAMS_FOUND_IN_RESOURCE_FILE.put("parameter2", "value");
-    }
-
-    private FakeAuthServer cognito;
-    private HttpClient httpClient;
-    private String userAccessToken;
-
-
-    @BeforeEach
-    public void init() {
-        this.cognito = new FakeAuthServer();
-        this.httpClient = WiremockHttpClient.create();
-        this.userAccessToken = randomString();
-    }
-
-    @AfterEach
-    public void close() {
-        this.cognito.close();
     }
 
     @Test
@@ -200,20 +174,8 @@ class RequestInfoTest {
         throws UnauthorizedException {
         var expectedCurrentCustomer = randomUri();
         var cognitoUserEntry = createCognitoUserEntry(expectedCurrentCustomer, null);
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
 
-        RequestInfo requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
-        var actualCustomerId = requestInfo.getCurrentCustomer();
-        assertThat(actualCustomerId, is(equalTo(expectedCurrentCustomer)));
-    }
-
-    @Test
-    void shouldReturnUserInfoWhenRequestContainsAccessTokenWithAdminScope() throws UnauthorizedException {
-        var expectedCurrentCustomer = randomUri();
-        var cognitoUserEntry = createCognitoUserEntry(expectedCurrentCustomer, null);
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-
-        RequestInfo requestInfo = createRequestInfoWithAccessTokenThatHasAdminScope();
+        RequestInfo requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var actualCustomerId = requestInfo.getCurrentCustomer();
         assertThat(actualCustomerId, is(equalTo(expectedCurrentCustomer)));
     }
@@ -222,13 +184,11 @@ class RequestInfoTest {
     void shouldReturnThatUserHasAccessRightForSpecificCustomerWhenCognitoHasRespectiveEntryAndUsesLegacyFormat() {
         var usersCustomer = randomUri();
         var accessRights = randomAccessRights();
-        var accessRightsForCustomer = accessRights.stream()
-                                          .map(AccessRight::toPersistedString)
-                                          .map(right -> right + AT + usersCustomer)
-                                          .collect(Collectors.toSet());
-        var cognitoUserEntry = createCognitoUserEntry(usersCustomer, accessRightsForCustomer);
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        Set<String> shortAccessRights = accessRights.stream()
+                                            .map(AccessRight::toPersistedString)
+                                            .collect(Collectors.toSet());
+        var cognitoUserEntry = createCognitoUserEntry(usersCustomer, shortAccessRights);
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         for (var accessRight : accessRights) {
             var userIsAuthorized = requestInfo.userIsAuthorized(accessRight);
             assertThat(userIsAuthorized, is(true));
@@ -243,8 +203,7 @@ class RequestInfoTest {
                                           .map(AccessRight::toPersistedString)
                                           .collect(Collectors.toSet());
         var cognitoUserEntry = createCognitoUserEntry(usersCustomer, accessRightsForCustomer);
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         for (var accessRight : accessRights) {
             var userIsAuthorized = requestInfo.userIsAuthorized(accessRight);
             assertThat(userIsAuthorized, is(true));
@@ -261,8 +220,7 @@ class RequestInfoTest {
                                    .withAccessRights(accessRightsForCustomer)
                                    .build();
 
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var requestedAccessRight = MANAGE_DOI;
         var userIsAuthorized = requestInfo.userIsAuthorized(requestedAccessRight);
         assertThat(userIsAuthorized, is(false));
@@ -275,30 +233,35 @@ class RequestInfoTest {
     @Test
     void shouldReturnThatUserDoesNotHaveAccessRightForSpecificCustomerWhenUserDoesNotHaveAnyAccessRights() {
         var cognitoUserEntryWithoutAccessRights = CognitoUserInfo.builder().withCurrentCustomer(randomUri()).build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntryWithoutAccessRights));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntryWithoutAccessRights);
         var requestedAccessRight = randomAccessRight();
         assertThat(requestInfo.userIsAuthorized(requestedAccessRight), is(false));
     }
 
     @Test
-    void shouldReturnThatUserIsAuthorizedWhenRequestInfoContainsACustomerIdAndTheRequestedAccessRight()
-        throws JsonProcessingException, ApiIoException {
+    void shouldReturnThatUserIsAuthorizedWhenRequestInfoContainsACustomerIdAndTheRequestedAccessRight() {
         var usersCustomer = randomUri();
-        var usersAccessRights = List.of(randomAccessRight(), randomAccessRight());
-        RequestInfo requestInfo = createRequestInfoForOfflineAuthorization(usersAccessRights, usersCustomer);
+        var usersAccessRights = Set.of(randomAccessRight().toPersistedString(),
+                                       randomAccessRight().toPersistedString());
+        var cognitoUserEntry = CognitoUserInfo.builder()
+                                   .withCurrentCustomer(usersCustomer)
+                                   .withAccessRights(usersAccessRights)
+                                   .build();
+        RequestInfo requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         for (var accessRight : usersAccessRights) {
-            assertThat(requestInfo.userIsAuthorized(accessRight), is(true));
+            assertThat(requestInfo.userIsAuthorized(AccessRight.fromPersistedString(accessRight)), is(true));
         }
     }
 
     @Test
-    void shouldReturnNotAuthorizedWhenRequestInfoDoesNotContainTheRequestedAccessRightAndCheckIsPerformedOffline()
-        throws JsonProcessingException, ApiIoException {
+    void shouldReturnNotAuthorizedWhenRequestInfoDoesNotContainTheRequestedAccessRightAndCheckIsPerformedOffline() {
         var userCustomer = randomUri();
-        var usersAccessRights = List.of(MANAGE_DEGREE, MANAGE_IMPORT);
-        var requestInfo =
-            createRequestInfoForOfflineAuthorization(usersAccessRights, userCustomer);
+        var usersAccessRights = Set.of(MANAGE_DEGREE.toPersistedString(), MANAGE_IMPORT.toPersistedString());
+        var cognitoUserEntry = CognitoUserInfo.builder()
+                                   .withCurrentCustomer(userCustomer)
+                                   .withAccessRights(usersAccessRights)
+                                   .build();
+        RequestInfo requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var notAllocatedAccessRight = MANAGE_PUBLISHING_REQUESTS;
         assertThat(requestInfo.userIsAuthorized(notAllocatedAccessRight), is(false));
     }
@@ -316,7 +279,7 @@ class RequestInfoTest {
     @Test
     void shouldReturnApiIoExceptionWhenObjectMapperFails() {
         var request = "This is not a valid request";
-        assertThrows(ApiIoException.class, () -> RequestInfo.fromRequest(IoUtils.stringToStream(request), httpClient));
+        assertThrows(ApiIoException.class, () -> RequestInfo.fromRequest(IoUtils.stringToStream(request)));
     }
 
     @Test
@@ -353,7 +316,9 @@ class RequestInfoTest {
     @Test
     void isThirdPartyShouldReturnTrueWhenScopeContainsTheExternalIssuedUserPool()
         throws JsonProcessingException, ApiIoException {
-        var request = new HandlerRequestBuilder<Void>(dtoObjectMapper).withIssuer(EXTERNAL_USER_POOL_URL).build();
+        var request = new HandlerRequestBuilder<Void>(dtoObjectMapper).withIssuer(EXTERNAL_USER_POOL_URL)
+                          .withScope(THIRD_PARTY_PUBLICATION_UPSERT)
+                          .build();
         var requestInfo = getRequestInfo(request);
         assertThat(requestInfo.clientIsThirdParty(), is(true));
     }
@@ -376,7 +341,7 @@ class RequestInfoTest {
     }
 
     private RequestInfo getRequestInfo(InputStream request) throws ApiIoException {
-        return RequestInfo.fromRequest(request, httpClient);
+        return RequestInfo.fromRequest(request);
     }
 
     @Test
@@ -422,8 +387,7 @@ class RequestInfoTest {
         throws UnauthorizedException {
         var expectedUsername = randomString();
         var cognitoUserEntry = CognitoUserInfo.builder().withUserName(expectedUsername).build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var actualUsername = requestInfo.getUserName();
         assertThat(actualUsername, is(equalTo(expectedUsername)));
     }
@@ -431,8 +395,7 @@ class RequestInfoTest {
     @Test
     void shouldReturnUsernameWhenClaimInAvailableOffline() throws UnauthorizedException {
         var cognitoUserEntry = CognitoUserInfo.builder().withUserName(randomString()).build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
 
         var expectedUsername = randomString();
         injectUserNameInRequestInfo(requestInfo, expectedUsername);
@@ -444,8 +407,7 @@ class RequestInfoTest {
     @Test
     void shouldThrowUnauthorizedExceptionWhenUserNameIsNotAvailable() {
         var cognitoUserEntryWithoutUserName = CognitoUserInfo.builder().build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntryWithoutUserName));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntryWithoutUserName);
         assertThrows(UnauthorizedException.class, requestInfo::getUserName);
     }
 
@@ -453,9 +415,12 @@ class RequestInfoTest {
     void shouldReturnPersonCristinIdFromCognitoWhenUserHasSelectedCustomerAndClaimInNotAvailableOffline()
         throws UnauthorizedException {
         var expectedPersonCristinId = randomUri();
-        var cognitoUserEntry = CognitoUserInfo.builder().withPersonCristinId(expectedPersonCristinId).build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var cognitoUserEntry =
+            CognitoUserInfo.builder()
+                .withPersonCristinId(expectedPersonCristinId)
+                .withCurrentCustomer(randomUri())
+                .build();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var actualPersonCristinId = requestInfo.getPersonCristinId();
         assertThat(actualPersonCristinId, is(equalTo(expectedPersonCristinId)));
     }
@@ -463,8 +428,7 @@ class RequestInfoTest {
     @Test
     void shouldReturnPersonCristinIdWhenClaimInAvailableOffline() throws UnauthorizedException {
         var cognitoUserEntry = CognitoUserInfo.builder().withPersonCristinId(randomUri()).build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var expectedPersonCristinIdDifferentFromCognito = randomUri();
         injectPersonCristinIdInRequestInfo(requestInfo, expectedPersonCristinIdDifferentFromCognito);
         var actualPersonCristinId = requestInfo.getPersonCristinId();
@@ -474,8 +438,7 @@ class RequestInfoTest {
     @Test
     void shouldThrowUnauthorizedExceptionWhenPersonCristinIdIsNotAvailable() {
         var cognitoUserEntryWithoutPersonCristinId = CognitoUserInfo.builder().build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntryWithoutPersonCristinId));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntryWithoutPersonCristinId);
         assertThrows(UnauthorizedException.class, requestInfo::getPersonCristinId);
     }
 
@@ -492,8 +455,7 @@ class RequestInfoTest {
         throws UnauthorizedException {
         var expectedPersonAffiliation = randomUri();
         var cognitoUserEntry = CognitoUserInfo.builder().withPersonAffiliation(expectedPersonAffiliation).build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var actualPersonAffiliation = requestInfo.getPersonAffiliation();
         assertThat(actualPersonAffiliation, is(equalTo(expectedPersonAffiliation)));
     }
@@ -501,8 +463,7 @@ class RequestInfoTest {
     @Test
     void shouldReturnPersonAffiliationWhenClaimInAvailableOffline() throws UnauthorizedException {
         var cognitoUserEntry = CognitoUserInfo.builder().withPersonAffiliation(randomUri()).build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var expectedPersonAffiliationDifferentFromCognito = randomUri();
         injectPersonAffiliationInRequestInfo(requestInfo, expectedPersonAffiliationDifferentFromCognito);
         var actualPersonAffiliation = requestInfo.getPersonAffiliation();
@@ -512,8 +473,7 @@ class RequestInfoTest {
     @Test
     void shouldThrowUnauthorizedExceptionWhenPersonAffiliationIsNotAvailable() {
         var cognitoUserEntryWithoutPersonAffiliation = CognitoUserInfo.builder().build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntryWithoutPersonAffiliation));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntryWithoutPersonAffiliation);
         assertThrows(UnauthorizedException.class, requestInfo::getPersonAffiliation);
     }
 
@@ -528,8 +488,7 @@ class RequestInfoTest {
     @Test
     void shouldThrowUnauthorizedExceptionWhenCustomerIdIsNotAvailable() {
         var cognitoUserEntryWithoutCustomerId = CognitoUserInfo.builder().build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntryWithoutCustomerId));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntryWithoutCustomerId);
         assertThrows(UnauthorizedException.class, requestInfo::getCurrentCustomer);
     }
 
@@ -537,8 +496,7 @@ class RequestInfoTest {
     void shouldReturnTopLevelOrgCristinIdWhenCurrentCustomerHasBeenSelectedForPerson() {
         var topOrgCristinId = randomUri();
         var cognitoUserEntry = CognitoUserInfo.builder().withTopOrgCristinId(topOrgCristinId).build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         assertThat(requestInfo.getTopLevelOrgCristinId().orElseThrow(), is(equalTo(topOrgCristinId)));
     }
 
@@ -584,8 +542,7 @@ class RequestInfoTest {
     void shouldReturnPersonNinFromCognitoWhenUserHasPersonNinInClaimAndIsNotOffline() {
         var expectedPersonNin = randomString();
         var cognitoUserEntry = CognitoUserInfo.builder().withPersonNin(expectedPersonNin).build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var actualPersonNin = requestInfo.getPersonNin();
         assertThat(actualPersonNin, is(equalTo(expectedPersonNin)));
     }
@@ -593,8 +550,7 @@ class RequestInfoTest {
     @Test
     void shouldReturnPersonNinWhenUserHasPersonNinInClaimAvailableOffline() {
         var cognitoUserEntry = CognitoUserInfo.builder().withPersonNin(randomString()).build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var expectedPersonNinDifferentFromCognito = randomString();
         injectPersonNinInRequestInfo(requestInfo, expectedPersonNinDifferentFromCognito);
         var actualPersonNin = requestInfo.getPersonNin();
@@ -606,9 +562,9 @@ class RequestInfoTest {
         var expectedPersonFeideNin = randomString();
         var claims = dtoObjectMapper.createObjectNode();
         claims.put(CognitoUserInfo.PERSON_FEIDE_NIN_CLAIM, expectedPersonFeideNin);
+        claims.put(CognitoUserInfo.SELECTED_CUSTOMER_CLAIM, randomString());
         var cognitoUserInfo = objectMapper.readValue(claims.toString(), CognitoUserInfo.class);
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserInfo));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserInfo);
         var actualPersonNin = requestInfo.getPersonNin();
 
         assertThat(actualPersonNin, is(equalTo(expectedPersonFeideNin)));
@@ -618,8 +574,7 @@ class RequestInfoTest {
     void shouldReturnFeideIdFromCognitoWhenUserHasFeideIdInClaimAndIsNotOffline() {
         var expectedFeideId = randomString();
         var cognitoUserEntry = CognitoUserInfo.builder().withFeideId(expectedFeideId).build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var actualFeideId = requestInfo.getFeideId();
 
         assertThat(requestInfo.getFeideId().isPresent(), is(true));
@@ -629,8 +584,7 @@ class RequestInfoTest {
     @Test
     void shouldReturnFeideIdWhenUserHasFeideIdInClaimAvailableOffline() {
         var cognitoUserEntry = CognitoUserInfo.builder().withFeideId(randomString()).build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var expectedFeideIdDifferentFromCognito = randomString();
         injectFeideIdInRequestInfo(requestInfo, expectedFeideIdDifferentFromCognito);
         var actualFeideId = requestInfo.getFeideId();
@@ -644,9 +598,9 @@ class RequestInfoTest {
         var expectedFeideId = randomString();
         var claims = dtoObjectMapper.createObjectNode();
         claims.put(CognitoUserInfo.PERSON_FEIDE_ID_CLAIM, expectedFeideId);
+        claims.put(CognitoUserInfo.SELECTED_CUSTOMER_CLAIM, randomString());
         var cognitoUserInfo = objectMapper.readValue(claims.toString(), CognitoUserInfo.class);
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserInfo));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserInfo);
         var actualFeideId = requestInfo.getFeideId();
 
         assertThat(requestInfo.getFeideId().isPresent(), is(true));
@@ -662,9 +616,9 @@ class RequestInfoTest {
 
         var claims = dtoObjectMapper.createObjectNode();
         claims.put(CognitoUserInfo.ACCESS_RIGHTS_CLAIM, accessRightsString);
+        claims.put(CognitoUserInfo.SELECTED_CUSTOMER_CLAIM, randomString());
         var cognitoUserInfo = objectMapper.readValue(claims.toString(), CognitoUserInfo.class);
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserInfo));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserInfo);
         var actualAccessRights = requestInfo.getAccessRights();
 
         assertThat(actualAccessRights, containsInAnyOrder(accessRights.toArray()));
@@ -673,8 +627,7 @@ class RequestInfoTest {
     @Test
     void shouldReturnOptionalEmptyWhenUserDoesNotHaveFeideId() {
         var cognitoUserEntryWithoutFeideId = CognitoUserInfo.builder().build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntryWithoutFeideId));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntryWithoutFeideId);
 
         assertThat(requestInfo.getFeideId().isPresent(), is(false));
         assertThat(requestInfo.getFeideId(), is(Optional.empty()));
@@ -683,45 +636,15 @@ class RequestInfoTest {
     @Test
     void shouldThrowIllegalStateExceptionWhenNoTypeOfPersonNinIsAvailable() {
         var cognitoUserEntryWithoutPersonNin = CognitoUserInfo.builder().build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntryWithoutPersonNin));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntryWithoutPersonNin);
 
         assertThrows(IllegalStateException.class, requestInfo::getPersonNin);
     }
 
     @Test
-    void shouldLogFailureWhenFailingToFetchInfoFromCognito() {
-        var cognitoUserEntry = CognitoUserInfo.builder().withPersonNin(randomString()).build();
-        cognito.setUserBase(Map.of(randomString(), cognitoUserEntry));
-        var logger = LogUtils.getTestingAppenderForRootLogger();
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
-        assertThrows(UnauthorizedException.class, requestInfo::getUserName);
-        assertThat(logger.getMessages(),
-                   containsString(ERROR_FETCHING_COGNITO_INFO.replace(LOG_STRING_INTERPOLATION, EMPTY_STRING)));
-    }
-
-    @Test
-    void shouldReturnListOfAccessRightsAvailableForUser()
-        throws JsonProcessingException, ApiIoException {
-        var usersCustomer = randomUri();
-        var accessRights = List.of(MANAGE_DEGREE, MANAGE_IMPORT, MANAGE_NVI);
-        var accessRightsForCustomer = accessRights.stream()
-                                          .map(AccessRight::toPersistedString)
-                                          .map(right -> right + AT + usersCustomer)
-                                          .collect(Collectors.toSet());
-        var cognitoUserEntry = createCognitoUserEntry(usersCustomer, accessRightsForCustomer);
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoForOfflineAuthorization(accessRights, usersCustomer);
-        var rights = requestInfo.getAccessRights();
-
-        assertThat(rights, containsInAnyOrder(accessRights.toArray()));
-    }
-
-    @Test
     void shouldReturnEmptyListWhenAccessRightsCognitoStringIsEmpty() {
         var cognitoUserEntry = CognitoUserInfo.builder().build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var accessRights = requestInfo.getAccessRights();
 
         assertThat(accessRights, is(emptyIterable()));
@@ -729,13 +652,13 @@ class RequestInfoTest {
 
     @ParameterizedTest
     @MethodSource("emptyViewingScopeInputsProvider")
-    void shouldReturnEmptyViewingScopeIfNotPresentForUser(String includes, String excludes) throws UnauthorizedException {
+    void shouldReturnEmptyViewingScopeIfNotPresentForUser(String includes, String excludes)
+        throws UnauthorizedException {
         var cognitoUserEntry = CognitoUserInfo.builder()
                                    .withViewingScopeIncluded(includes)
                                    .withViewingScopeExcluded(excludes)
                                    .build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var getViewingScope = requestInfo.getViewingScope();
         assertThat(getViewingScope.includes(), is(emptyIterable()));
         assertThat(getViewingScope.excludes(), is(emptyIterable()));
@@ -755,9 +678,9 @@ class RequestInfoTest {
         var cognitoUserEntry = CognitoUserInfo.builder()
                                    .withViewingScopeIncluded("1,2")
                                    .withViewingScopeExcluded("3,4")
+                                   .withCurrentCustomer(randomUri())
                                    .build();
-        cognito.setUserBase(Map.of(userAccessToken, cognitoUserEntry));
-        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope();
+        var requestInfo = createRequestInfoWithAccessTokenThatHasOpenIdScope(cognitoUserEntry);
         var getViewingScope = requestInfo.getViewingScope();
         assertThat(getViewingScope.includes(), is(hasItems("1", "2")));
         assertThat(getViewingScope.excludes(), is(hasItems("3", "4")));
@@ -841,32 +764,33 @@ class RequestInfoTest {
         requestInfo.setRequestContext(requestContext);
     }
 
-    private RequestInfo createRequestInfoWithAccessTokenThatHasOpenIdScope() {
-        var cognitoServerUri = UriWrapper.fromUri(cognito.getServerUri()).addChild(OAUTH_USER_INFO).getUri();
-        // having openid scope means that the default cognito URI will be the successful one
-        var requestInfo = new RequestInfo(httpClient, () -> cognitoServerUri, failingUri());
-        requestInfo.setHeaders(Map.of(HttpHeaders.AUTHORIZATION, bearerToken(userAccessToken)));
-        return requestInfo;
+    private static ObjectNode getRequestContext(CognitoUserInfo user) {
+        var claims = dtoObjectMapper.createObjectNode();
+        var authorizer = dtoObjectMapper.createObjectNode();
+        var requestContext = dtoObjectMapper.createObjectNode();
+        user.getClaims().forEach(claims::put);
+
+        if (nonNull(user.getCurrentCustomer())) {
+            var customerAccessRigts = Arrays.stream(user.getAccessRights().split(","))
+                                          .map(right -> right + AT + user.getCurrentCustomer().toString())
+                                          .collect(Collectors.joining(","));
+            claims.put(PERSON_GROUPS_CLAIM, customerAccessRigts);
+        }
+
+        authorizer.set("claims", claims);
+        requestContext.set("authorizer", authorizer);
+        return requestContext;
     }
 
-    private RequestInfo createRequestInfoWithAccessTokenThatHasAdminScope() {
-        var cognitoServerUri = UriWrapper.fromUri(cognito.getServerUri()).addChild(OAUTH_USER_INFO).getUri();
-        // having admin scope means that the default cognito URI will fail and the alternative be the successful one
-        var requestInfo = new RequestInfo(httpClient, failingUri(), () -> cognitoServerUri);
-        requestInfo.setHeaders(Map.of(HttpHeaders.AUTHORIZATION, bearerToken(userAccessToken)));
-        return requestInfo;
-    }
+    private RequestInfo createRequestInfoWithAccessTokenThatHasOpenIdScope(CognitoUserInfo user) {
 
-    private Supplier<URI> failingUri() {
-        return RandomDataGenerator::randomUri;
-    }
-
-    private RequestInfo createRequestInfoForOfflineAuthorization(List<AccessRight> accessRights, URI userCustomer)
-        throws JsonProcessingException, ApiIoException {
-        var requestStream = new HandlerRequestBuilder<Void>(dtoObjectMapper)
-                                .withAccessRights(userCustomer, accessRights.toArray(AccessRight[]::new))
-                                .build();
-        return getRequestInfo(requestStream);
+        try {
+            var info = RequestInfo.fromString("{}");
+            info.setRequestContext(getRequestContext(user));
+            return info;
+        } catch (ApiIoException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private RequestInfo createRequestInfoWithViewScopeRequestContext(String includes, String excludes)
@@ -876,10 +800,6 @@ class RequestInfoTest {
                                 .withAuthorizerClaim("custom:viewingScopeExcluded", excludes)
                                 .build();
         return getRequestInfo(requestStream);
-    }
-
-    private String bearerToken(String userAccessToken) {
-        return "Bearer " + userAccessToken;
     }
 
     private RequestInfo extractAccessRightsFromApiGatewayEvent() throws ApiIoException {

--- a/apigateway/src/test/java/nva/commons/apigateway/RequestInfoUtilityFunctionsTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/RequestInfoUtilityFunctionsTest.java
@@ -6,13 +6,11 @@ import static nva.commons.apigateway.RequestInfoConstants.MISSING_FROM_QUERY_PAR
 import static nva.commons.apigateway.RequestInfoConstants.MISSING_FROM_REQUEST_CONTEXT;
 import static nva.commons.apigateway.RestConfig.defaultRestObjectMapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Map;
 import no.unit.nva.testutils.HandlerRequestBuilder;
@@ -32,8 +30,7 @@ public class RequestInfoUtilityFunctionsTest {
     @BeforeEach
     public void setUp() throws JsonProcessingException, ApiIoException {
         var request = new HandlerRequestBuilder<String>(defaultRestObjectMapper).build();
-        var httpClient = mock(HttpClient.class);
-        RequestInfo spiedObject = RequestInfo.fromRequest(request, httpClient);
+        RequestInfo spiedObject = RequestInfo.fromRequest(request);
         requestInfo = spy(spiedObject);
     }
 

--- a/apigateway/src/test/java/nva/commons/apigateway/VoidTest.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/VoidTest.java
@@ -12,7 +12,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.http.HttpClient;
 import java.nio.file.Path;
 import no.unit.nva.stubs.FakeContext;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
@@ -32,7 +31,6 @@ public class VoidTest {
 
     private Environment environment;
     private Context context;
-    private HttpClient httpClient;
 
     /**
      * Setup.
@@ -44,7 +42,6 @@ public class VoidTest {
         context = new FakeContext();
         when(environment.readEnv(anyString())).thenReturn(SOME_ENV_VALUE);
         when(environment.readEnv(ALLOWED_ORIGIN_ENV)).thenReturn("*");
-        httpClient = mock(HttpClient.class);
     }
 
     @DisplayName("handleRequest returns success when input class is void and body field is missing from "
@@ -70,7 +67,7 @@ public class VoidTest {
     private ByteArrayOutputStream responseFromVoidHandler(String missingBodyRequest) throws IOException {
         InputStream input = IoUtils.inputStreamFromResources(Path.of(APIGATEWAY_MESSAGES_FOLDER, missingBodyRequest));
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        VoidHandler handler = new VoidHandler(environment, httpClient);
+        VoidHandler handler = new VoidHandler(environment);
         handler.handleRequest(input, outputStream, context);
         return outputStream;
     }
@@ -79,8 +76,8 @@ public class VoidTest {
 
         public static final String SAMPLE_STRING = "sampleString";
 
-        public VoidHandler(Environment environment, HttpClient httpClient) {
-            super(Void.class, environment, httpClient);
+        public VoidHandler(Environment environment) {
+            super(Void.class, environment);
         }
 
         @Override

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/Handler.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/Handler.java
@@ -4,7 +4,6 @@ import static nva.commons.apigateway.RequestInfoConstants.PROXY_TAG;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.google.common.net.HttpHeaders;
 import java.net.HttpURLConnection;
-import java.net.http.HttpClient;
 import java.util.Collections;
 import java.util.Map;
 import nva.commons.apigateway.ApiGatewayHandler;
@@ -26,8 +25,8 @@ public class Handler extends ApiGatewayHandler<RequestBody, RequestBody> {
     /**
      * Constructor that overrides default serialization.
      */
-    public Handler(Environment environment, HttpClient httpClient) {
-        super(RequestBody.class, environment, httpClient);
+    public Handler(Environment environment) {
+        super(RequestBody.class, environment);
     }
 
     @Override

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/ProxyHandler.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/ProxyHandler.java
@@ -3,7 +3,6 @@ package nva.commons.apigateway.testutils;
 import static nva.commons.apigateway.RequestInfoConstants.PROXY_TAG;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.google.common.net.HttpHeaders;
-import java.net.http.HttpClient;
 import java.util.Collections;
 import java.util.Map;
 import nva.commons.apigateway.ApiGatewayProxyHandler;
@@ -27,8 +26,8 @@ public class ProxyHandler extends ApiGatewayProxyHandler<RequestBody, RequestBod
     /**
      * Constructor that overrides default serialization.
      */
-    public ProxyHandler(Environment environment, HttpClient httpClient) {
-        super(RequestBody.class, environment, httpClient);
+    public ProxyHandler(Environment environment) {
+        super(RequestBody.class, environment);
     }
     
     @Override

--- a/apigateway/src/test/java/nva/commons/apigateway/testutils/RawStringResponseHandler.java
+++ b/apigateway/src/test/java/nva/commons/apigateway/testutils/RawStringResponseHandler.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 import java.net.HttpURLConnection;
-import java.net.http.HttpClient;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,8 +32,8 @@ public class RawStringResponseHandler extends ApiGatewayHandler<RequestBody, Str
     /**
      * Constructor that overrides default serialization.
      */
-    public RawStringResponseHandler(Environment environment, HttpClient httpClient) {
-        super(RequestBody.class, environment, httpClient);
+    public RawStringResponseHandler(Environment environment) {
+        super(RequestBody.class, environment);
     }
 
     @Override

--- a/auth/src/main/java/no/unit/nva/auth/CognitoUserInfo.java
+++ b/auth/src/main/java/no/unit/nva/auth/CognitoUserInfo.java
@@ -4,6 +4,8 @@ import static java.util.Objects.nonNull;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import nva.commons.core.JacocoGenerated;
@@ -13,11 +15,12 @@ public class CognitoUserInfo {
 
     public static final String ELEMENTS_DELIMITER = ",";
     public static final String EMPTY_STRING = "";
+
+    // Claims
     public static final String PERSON_FEIDE_ID_CLAIM = "custom:feideId";
     public static final String SELECTED_CUSTOMER_CLAIM = "custom:customerId";
     public static final String ACCESS_RIGHTS_CLAIM = "custom:accessRights";
     public static final String USER_NAME_CLAIM = "custom:nvaUsername";
-    public static final String CUSTOMER_ID_CLAIM = "custom:customerId";
     public static final String TOP_LEVEL_ORG_CRISTIN_ID_CLAIM = "custom:topOrgCristinId";
     public static final String PERSON_CRISTIN_ID_CLAIM = "custom:cristinId";
     public static final String PERSON_NIN_CLAIM = "custom:nin";
@@ -216,6 +219,38 @@ public class CognitoUserInfo {
                && Objects.equals(getFeideId(), that.getFeideId())
                && Objects.equals(getViewingScopeIncluded(), that.getViewingScopeIncluded())
                && Objects.equals(getViewingScopeExcluded(), that.getViewingScopeExcluded());
+    }
+
+    public Map<String, String> getClaims() {
+        var claims = new HashMap<String, String>();
+        addClaimUnlessNull(claims, PERSON_FEIDE_ID_CLAIM, getFeideId());
+        addClaimUnlessNull(claims, SELECTED_CUSTOMER_CLAIM, getCurrentCustomer());
+        addClaimUnlessNull(claims, ACCESS_RIGHTS_CLAIM, getAccessRights());
+        addClaimUnlessNull(claims, USER_NAME_CLAIM, getUserName());
+        addClaimUnlessNull(claims, TOP_LEVEL_ORG_CRISTIN_ID_CLAIM, getTopOrgCristinId());
+        addClaimUnlessNull(claims, PERSON_CRISTIN_ID_CLAIM, getPersonCristinId());
+        addClaimUnlessNull(claims, PERSON_NIN_CLAIM, getPersonNin());
+        addClaimUnlessNull(claims, PERSON_FEIDE_NIN_CLAIM, getPersonNin());
+        addClaimUnlessNull(claims, ROLES, getRoles());
+        addClaimUnlessNull(claims, SUB, getSub());
+        addClaimUnlessNull(claims, PERSON_AFFILIATION_CLAIM, getPersonAffiliation());
+        addClaimUnlessNull(claims, ALLOWED_CUSTOMERS, getAllowedCustomers());
+        addClaimUnlessNull(claims, COGNITO_USER_NAME, getCognitoUsername());
+        addClaimUnlessNull(claims, VIEWING_SCOPE_INCLUDED_CLAIM, getViewingScopeIncluded());
+        addClaimUnlessNull(claims, VIEWING_SCOPE_EXCLUDED_CLAIM, getViewingScopeExcluded());
+        return claims;
+    }
+
+    private void addClaimUnlessNull(HashMap<String, String> claims, String key, URI value) {
+        if (nonNull(value)) {
+            claims.put(key, value.toString());
+        }
+    }
+
+    private void addClaimUnlessNull(HashMap<String, String> claims, String key, String value) {
+        if (nonNull(value)) {
+            claims.put(key, value);
+        }
     }
 
     public static final class Builder {

--- a/auth/src/main/java/no/unit/nva/auth/CognitoUserInfo.java
+++ b/auth/src/main/java/no/unit/nva/auth/CognitoUserInfo.java
@@ -26,6 +26,7 @@ public class CognitoUserInfo {
     public static final String PERSON_NIN_CLAIM = "custom:nin";
     public static final String PERSON_FEIDE_NIN_CLAIM = "custom:feideIdNin";
     public static final String ROLES = "custom:roles";
+    public static final String PERSON_GROUPS_CLAIM = "cognito:groups";
     public static final String SUB = "sub";
     public static final String PERSON_AFFILIATION_CLAIM = "custom:personAffiliation";
     public static final String ALLOWED_CUSTOMERS = "custom:allowedCustomers";

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 
 
 group = 'com.github.bibsysdev'
-version = '1.41.9'
+version = '2.0.0'
 
 
 java {

--- a/nvatestutils/src/main/java/no/unit/nva/testutils/HandlerRequestBuilder.java
+++ b/nvatestutils/src/main/java/no/unit/nva/testutils/HandlerRequestBuilder.java
@@ -4,6 +4,7 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static no.unit.nva.auth.CognitoUserInfo.ACCESS_RIGHTS_CLAIM;
 import static no.unit.nva.auth.CognitoUserInfo.ALLOWED_CUSTOMERS;
+import static no.unit.nva.auth.CognitoUserInfo.EMPTY_STRING;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -52,6 +53,7 @@ public class HandlerRequestBuilder<T> {
     public static final String CLIENT_ID_CLAIM = "client_id";
     public static final String PERSON_NIN_CLAIM = "custom:nin";
     private static final String TOP_LEVEL_ORG_CRISTIN_ID_CLAIM = "custom:topOrgCristinId";
+    private static final String COMMA = ",";
     private final ObjectMapper objectMapper;
     @JsonProperty("body")
     private String body;
@@ -187,7 +189,7 @@ public class HandlerRequestBuilder<T> {
     }
 
     public HandlerRequestBuilder<T> withUserName(String userName) {
-        ObjectNode claims = getAuthorizerClaimsNode();
+        var claims = getAuthorizerClaimsNode();
         claims.put(USER_NAME_CLAIM, userName);
         return this;
     }
@@ -199,13 +201,13 @@ public class HandlerRequestBuilder<T> {
     }
 
     public HandlerRequestBuilder<T> withCurrentCustomer(URI customerId) {
-        ObjectNode claims = getAuthorizerClaimsNode();
+        var claims = getAuthorizerClaimsNode();
         claims.put(CUSTOMER_ID, customerId.toString());
         return this;
     }
 
     public HandlerRequestBuilder<T> withAllowedCustomers(Set<URI> customers) {
-        ObjectNode claims = getAuthorizerClaimsNode();
+        var claims = getAuthorizerClaimsNode();
         claims.put(ALLOWED_CUSTOMERS, customers.stream().map(URI::toString).collect(Collectors.joining(",")));
         return this;
     }
@@ -217,31 +219,31 @@ public class HandlerRequestBuilder<T> {
     }
 
     public HandlerRequestBuilder<T> withTopLevelCristinOrgId(URI topLevelCristinOrgId) {
-        ObjectNode claims = getAuthorizerClaimsNode();
+        var claims = getAuthorizerClaimsNode();
         claims.put(TOP_LEVEL_ORG_CRISTIN_ID_CLAIM, topLevelCristinOrgId.toString());
         return this;
     }
 
     public HandlerRequestBuilder<T> withPersonCristinId(URI personCristinId) {
-        ObjectNode claims = getAuthorizerClaimsNode();
+        var claims = getAuthorizerClaimsNode();
         claims.put(PERSON_CRISTIN_ID, personCristinId.toString());
         return this;
     }
 
     public HandlerRequestBuilder<T> withPersonNin(String personNin) {
-        ObjectNode claims = getAuthorizerClaimsNode();
+        var claims = getAuthorizerClaimsNode();
         claims.put(PERSON_NIN_CLAIM, personNin);
         return this;
     }
 
     public HandlerRequestBuilder<T> withFeideId(String feideId) {
-        ObjectNode claims = getAuthorizerClaimsNode();
+        var claims = getAuthorizerClaimsNode();
         claims.put(FEIDE_ID_CLAIM, feideId);
         return this;
     }
 
     public HandlerRequestBuilder<T> withRoles(String roles) {
-        ObjectNode claims = getAuthorizerClaimsNode();
+        var claims = getAuthorizerClaimsNode();
         claims.put(APPLICATION_ROLES_CLAIM, roles);
         return this;
     }
@@ -252,10 +254,10 @@ public class HandlerRequestBuilder<T> {
             addAccessRightToCognitoGroups(accessRightEntry);
         }
 
-        ObjectNode claims = getAuthorizerClaimsNode();
+        var claims = getAuthorizerClaimsNode();
         var accessRightsString = Arrays.stream(accessRights)
                                      .map(AccessRight::toPersistedString)
-                                     .collect(Collectors.joining(","));
+                                     .collect(Collectors.joining(COMMA));
         claims.put(ACCESS_RIGHTS_CLAIM, accessRightsString);
 
         return this;
@@ -301,7 +303,7 @@ public class HandlerRequestBuilder<T> {
 
     private Collection<AccessRightEntry> extractAccessRights(ObjectNode claims) {
         return new ArrayList<>(
-            AccessRightEntry.fromCsv(Optional.ofNullable(claims.get(GROUPS_CLAIM)).map(JsonNode::asText).orElse(""))
+            AccessRightEntry.fromCsv(Optional.ofNullable(claims.get(GROUPS_CLAIM)).map(JsonNode::asText).orElse(EMPTY_STRING))
                 .toList());
     }
 

--- a/nvatestutils/src/test/java/no/unit/nva/testutils/HandlerRequestBuilderTest.java
+++ b/nvatestutils/src/test/java/no/unit/nva/testutils/HandlerRequestBuilderTest.java
@@ -24,8 +24,10 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import no.unit.nva.auth.CognitoUserInfo;
 import no.unit.nva.commons.json.JsonUtils;
+import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiIoException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
@@ -144,6 +146,7 @@ class HandlerRequestBuilderTest {
         var expectedCustomerId = randomUri();
         var requestStream = new HandlerRequestBuilder<String>(objectMapper)
                                 .withCurrentCustomer(expectedCustomerId)
+                                .withAllowedCustomers(Set.of(expectedCustomerId))
                                 .build();
         var request = IoUtils.streamToString(requestStream);
         var requestInfo = JsonUtils.dtoObjectMapper.readValue(request, RequestInfo.class);
@@ -151,7 +154,7 @@ class HandlerRequestBuilderTest {
     }
 
     @Test
-    void buildReturnsPersonsFeideIdWhenSet() throws JsonProcessingException, ApiIoException {
+    void buildReturnsPersonsFeideIdWhenSet() throws JsonProcessingException, ApiIoException, UnauthorizedException {
         var expectedFeideId = randomString();
         var request = new HandlerRequestBuilder<String>(objectMapper)
                           .withFeideId(expectedFeideId)
@@ -164,7 +167,7 @@ class HandlerRequestBuilderTest {
 
     @Test
     void buildReturnsEmptyOptionalWhenFeideIdNotSet()
-        throws JsonProcessingException, ApiIoException {
+        throws JsonProcessingException, ApiIoException, UnauthorizedException {
         var request = new HandlerRequestBuilder<String>(objectMapper).build();
         var requestInfo = RequestInfo.fromRequest(request);
 
@@ -192,7 +195,9 @@ class HandlerRequestBuilderTest {
         var expectedApplicationRoles = "role1,role2";
 
         InputStream requestStream = new HandlerRequestBuilder<String>(objectMapper).withUserName(expectedUsername)
-                                        .withAccessRights(expectedCustomerId, randomAccessRight())
+                                        .withAccessRights(expectedCustomerId, randomAccessRight(),
+                                                          AccessRight.MANAGE_DEGREE,
+                                                          AccessRight.MANAGE_RESOURCES_STANDARD)
                                         .withRoles(expectedApplicationRoles)
                                         .build();
         JsonNode request = toJsonNode(requestStream);


### PR DESCRIPTION
all our current authenticated APIs authorize the request by doing online query to cognito user attributes, probably multiple times. When we now have all needed claims available in the access token, this is not needed today and we should use the information already available. Also expose getAllowedCustomers for the bankid-customer selection where we need this information in identity service handler. We also start move away from using "cognito:groups" claim.

At first I did not plan to do this change right away, but it was forced forward because CustomerSelectionHandler started failing when we removed the aws.cognito.signin.user.admin scope, and removing the scope is the goal of all this.