### PR TITLE
adding fetch channel claim method to identity service client

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 
 
 group = 'com.github.bibsysdev'
-version = '2.2.1'
+version = '2.2.2'
 
 
 java {

--- a/clients/src/main/java/no/unit/nva/clients/ChannelClaimDto.java
+++ b/clients/src/main/java/no/unit/nva/clients/ChannelClaimDto.java
@@ -1,0 +1,33 @@
+package no.unit.nva.clients;
+
+import static no.unit.nva.clients.ChannelClaimDto.CLAIMED_CHANNEL_TYPE;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.net.URI;
+import java.util.List;
+import no.unit.nva.commons.json.JsonSerializable;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeName(CLAIMED_CHANNEL_TYPE)
+public record ChannelClaimDto(CustomerSummaryDto claimedBy, ChannelClaim channelClaim) implements JsonSerializable {
+
+    static final String CLAIMED_CHANNEL_TYPE = "ClaimedChannel";
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonTypeName(ChannelClaim.CHANNEL_CLAIM_TYPE)
+    public record ChannelClaim(URI channel, ChannelConstraint constraint) {
+
+        private static final String CHANNEL_CLAIM_TYPE = "ChannelClaim";
+
+        public record ChannelConstraint(String publishingPolicy, String editingPolicy, List<String> scope) {
+
+        }
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonTypeName(CustomerSummaryDto.TYPE)
+    public record CustomerSummaryDto(URI id, URI organizationId) {
+
+        private static final String TYPE = "Customer";
+    }
+}

--- a/clients/src/main/java/no/unit/nva/clients/IdentityServiceClient.java
+++ b/clients/src/main/java/no/unit/nva/clients/IdentityServiceClient.java
@@ -99,10 +99,18 @@ public class IdentityServiceClient {
                    .orElseThrow(this::handleFailure);
     }
 
-    private static Builder getRequestBuilderFromUri(URI customerId) {
+    public ChannelClaimDto getChannelClaim(URI channelClaim) throws NotFoundException {
+        var request = getRequestBuilderFromUri(channelClaim);
+        return attempt(getHttpResponseCallable(request))
+                   .map(this::validateResponse)
+                   .map(r -> mapResponse(ChannelClaimDto.class, r))
+                   .orElseThrow(this::handleFailure);
+    }
+
+    private static Builder getRequestBuilderFromUri(URI uri) {
         return HttpRequest.newBuilder()
                    .GET()
-                   .uri(customerId);
+                   .uri(uri);
     }
 
     public CustomerList getAllCustomers() throws ApiGatewayException {

--- a/clients/src/main/java/no/unit/nva/clients/IdentityServiceClient.java
+++ b/clients/src/main/java/no/unit/nva/clients/IdentityServiceClient.java
@@ -58,7 +58,7 @@ public class IdentityServiceClient {
         var request = getRequestBuilderFromUri(constructExternalClientsGetPath(clientId));
         return attempt(getHttpResponseCallable(request))
                    .map(this::validateResponse)
-                   .map(r -> mapResponse(GetExternalClientResponse.class, r))
+                   .map(response -> mapResponse(GetExternalClientResponse.class, response))
                    .orElseThrow(this::handleFailure);
     }
 
@@ -71,7 +71,7 @@ public class IdentityServiceClient {
 
         return attempt(() -> unauthorizedClient.send(request.build(), ofString(UTF_8)))
                    .map(this::validateResponse)
-                   .map(r -> mapResponse(GetExternalClientResponse.class, r))
+                   .map(response -> mapResponse(GetExternalClientResponse.class, response))
                    .orElseThrow(this::handleFailure);
     }
 
@@ -79,7 +79,7 @@ public class IdentityServiceClient {
         var request = getRequestBuilderFromUri(constructUserGetPath(userName));
         return attempt(getHttpResponseCallable(request))
                    .map(this::validateResponse)
-                   .map(r -> mapResponse(UserDto.class, r))
+                   .map(response -> mapResponse(UserDto.class, response))
                    .orElseThrow(this::handleFailure);
     }
 
@@ -87,7 +87,7 @@ public class IdentityServiceClient {
         var request = getRequestBuilderFromUri(constructCustomerGetPath(topLevelOrgCristinId));
         return attempt(getHttpResponseCallable(request))
                    .map(this::validateResponse)
-                   .map(r -> mapResponse(CustomerDto.class, r))
+                   .map(response -> mapResponse(CustomerDto.class, response))
                    .orElseThrow(this::handleFailure);
     }
 
@@ -95,7 +95,7 @@ public class IdentityServiceClient {
         var request = getRequestBuilderFromUri(customerId);
         return attempt(getHttpResponseCallable(request))
                    .map(this::validateResponse)
-                   .map(r -> mapResponse(CustomerDto.class, r))
+                   .map(response -> mapResponse(CustomerDto.class, response))
                    .orElseThrow(this::handleFailure);
     }
 
@@ -103,7 +103,7 @@ public class IdentityServiceClient {
         var request = getRequestBuilderFromUri(channelClaim);
         return attempt(getHttpResponseCallable(request))
                    .map(this::validateResponse)
-                   .map(r -> mapResponse(ChannelClaimDto.class, r))
+                   .map(response -> mapResponse(ChannelClaimDto.class, response))
                    .orElseThrow(this::handleFailure);
     }
 
@@ -183,7 +183,7 @@ public class IdentityServiceClient {
             return new NotFoundException(exception);
         }
 
-        throw new RuntimeException();
+        throw new RuntimeException("Something went wrong!");
     }
 
     private <S> HttpResponse<String> validateResponse(HttpResponse<String> response) throws NotFoundException {


### PR DESCRIPTION
Adding `getChannelClaim()` method to `IdentityServiceClient` to be able to fetch ChannelClaim in `publication-api`.