### PR TITLE
adding id field to channel claim dto

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 
 
 group = 'com.github.bibsysdev'
-version = '2.2.4'
+version = '2.2.5'
 
 
 java {

--- a/clients/src/main/java/no/unit/nva/clients/ChannelClaimDto.java
+++ b/clients/src/main/java/no/unit/nva/clients/ChannelClaimDto.java
@@ -9,7 +9,7 @@ import no.unit.nva.commons.json.JsonSerializable;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonTypeName(CLAIMED_CHANNEL_TYPE)
-public record ChannelClaimDto(CustomerSummaryDto claimedBy, ChannelClaim channelClaim) implements JsonSerializable {
+public record ChannelClaimDto(URI id, CustomerSummaryDto claimedBy, ChannelClaim channelClaim) implements JsonSerializable {
 
     static final String CLAIMED_CHANNEL_TYPE = "ClaimedChannel";
 

--- a/clients/src/test/java/no/unit/nva/clients/IdentityServiceClientTest.java
+++ b/clients/src/test/java/no/unit/nva/clients/IdentityServiceClientTest.java
@@ -346,7 +346,7 @@ class IdentityServiceClientTest {
     }
 
     private ChannelClaimDto channelClaimWithId(URI channelClaim) {
-        return new ChannelClaimDto(new CustomerSummaryDto(
+        return new ChannelClaimDto(channelClaim, new CustomerSummaryDto(
             randomUri(), randomUri()), new ChannelClaim(channelClaim,
                                                         new ChannelConstraint(randomString(), randomString(),
                                                                                                        List.of(randomString(), randomString()))));


### PR DESCRIPTION
ChannelClaim from identity-service contains id. We will reuse it in publication-api, instead of constructing it based on publication-channel identifier. 