### PR TITLE
Remove references to vulnerable wiremock and checkstyle

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 
 
 group = 'com.github.bibsysdev'
-version = '2.2.9'
+version = '2.2.10'
 
 
 java {
@@ -83,6 +83,7 @@ jacocoTestReport {
 }
 
 checkstyle {
+    toolVersion = '10.26.1'
     configFile = rootProject.resources.text.fromFile('config/checkstyle/checkstyle.xml').asFile()
     showViolations = true
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ awsSdk = { strictly = '1.12.787' }
 awsSdk2 = { strictly = '2.31.77' }
 com-auth0-jwt = { strictly = '4.5.0' }
 com-auth0-jwks = { strictly = '0.22.2' }
-commonsValidator = { strictly = '1.9.0' }
+commonsValidator = { strictly = '1.10.0' }
 datafaker = { strictly = '2.4.3' }
 guava = { strictly = '33.4.8-jre' }
 hamcrest = { strictly = '3.0' }
@@ -19,7 +19,7 @@ lambdaLog4j = { strictly = '1.6.0' }
 log4j = { strictly = '2.25.0' }
 mockito = { strictly = '5.18.0' }
 slf4j = { strictly = '2.0.17' }
-wiremock = { strictly = '3.13.1' }
+wiremock = { strictly = '4.0.0-beta.14' }
 zalandoProblem = { strictly = '0.27.1' }
 
 [libraries]
@@ -78,8 +78,7 @@ mockito-core = { group = 'org.mockito', name = 'mockito-core', version.ref = 'mo
 datafaker = { group = 'net.datafaker', name = 'datafaker', version.ref = 'datafaker' }
 httpclient5 = { group = 'org.apache.httpcomponents.client5', name = 'httpclient5', version.ref = 'apacheHttpClient' }
 
-wiremock = { group = 'org.wiremock', name = 'wiremock-jetty12', version.ref = 'wiremock' }
-
+wiremock = { group = 'org.wiremock', name = 'wiremock', version.ref = 'wiremock' }
 
 com-auth0-jwt = { group = 'com.auth0', name = 'java-jwt', version.ref = 'com-auth0-jwt' }
 


### PR DESCRIPTION
- We were using wiremock-jetty12 because of a vulnerability, but this dependency has not been updated to patch further vulnerabilities in jetty
  - The patched version is unfortunately a beta release of the 4.0.0 branch, but this is a test dependency (which, in my opinion, we should largely avoid since it is not necessary in the vast majority of cases where we see it used)
- Checkstyle version is bumped to similarly avoid the same basic issue