### PR TITLE
feat: Publish version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,12 @@ allprojects{
     apply plugin: 'nvacommons.java-conventions'
 }
 
+catalog {
+    versionCatalog {
+        from(files("gradle/libs.versions.toml"))
+    }
+}
+
 wrapper {
     gradleVersion = '8.12.1'
     distributionType = Wrapper.DistributionType.ALL

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 
 
 group = 'com.github.bibsysdev'
-version = '2.2.8'
+version = '2.2.9'
 
 
 java {

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 
 
 group = 'com.github.bibsysdev'
-version = '2.2.9'
+version = '2.3.0'
 
 
 java {

--- a/buildSrc/src/main/groovy/nvacommons.publish-maven.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.publish-maven.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'maven-publish'
     id 'signing'
-    id 'version-catalog'
 }
 
 /***********************************ATTENTION*******************************************************
@@ -15,10 +14,6 @@ java {
 
 publishing {
     publications {
-        versionCatalog(MavenPublication) {
-            artifactId = project.name
-            from components.versionCatalog
-        }
         mavenJava(MavenPublication) {
             artifactId = project.name
             from components.java

--- a/buildSrc/src/main/groovy/nvacommons.publish-maven.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.publish-maven.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'maven-publish'
     id 'signing'
+    id 'version-catalog'
 }
 
 /***********************************ATTENTION*******************************************************
@@ -14,6 +15,10 @@ java {
 
 publishing {
     publications {
+        versionCatalog(MavenPublication) {
+            artifactId = project.name
+            from components.versionCatalog
+        }
         mavenJava(MavenPublication) {
             artifactId = project.name
             from components.java

--- a/buildSrc/src/main/groovy/nvacommons.root.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.root.gradle
@@ -3,12 +3,23 @@ plugins {
     id 'nvacommons.gradlelint'
     id 'nvacommons.java-conventions'
     id 'jacoco-report-aggregation'
+    id 'maven-publish'
     id 'version-catalog'
 }
 
 //workaround for jacoco-merge to work
 allprojects {
     apply plugin: 'nvacommons.java-conventions'
+}
+
+publishing {
+    publications {
+        // Publish the version catalog from the root project as an artifact
+        versionCatalog(MavenPublication) {
+            artifactId = 'versions'
+            from components.versionCatalog
+        }
+    }
 }
 
 nexusPublishing {

--- a/buildSrc/src/main/groovy/nvacommons.root.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.root.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'nvacommons.gradlelint'
     id 'nvacommons.java-conventions'
     id 'jacoco-report-aggregation'
+    id 'version-catalog'
 }
 
 //workaround for jacoco-merge to work


### PR DESCRIPTION
This publishes the version catalog in `nva-commons` as an artifact alongside the other artifacts. This can be combined with other version catalogs, such as the one we already define in each repository.