### PR TITLE
refactor: Make casing in libs.versions.toml consistent

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 
 
 group = 'com.github.bibsysdev'
-version = '2.3.3'
+version = '2.3.4'
 
 
 java {

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 
 
 group = 'com.github.bibsysdev'
-version = '2.3.2'
+version = '2.3.3'
 
 
 java {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,9 @@
 # Renaming a component (library, plugin, or bundle) or upgrading major versions of dependencies
 # is a breaking change and should be reflected in our version number.
 [versions]
-apache-poi = { strictly = '5.4.1' }
 apacheCommons = { require = '3.17.0' }
 apacheHttpClient = { strictly = '5.5' }
+apachePoi = { strictly = '5.4.1' }
 assertj = { strictly = '3.27.3' }
 awsIon = { strictly = '1.11.10' }
 awsLambdaCore = { strictly = '1.3.0' }
@@ -39,8 +39,8 @@ zalandoProblem = { strictly = '0.27.1' }
 
 [libraries]
 # IMPORTANT: Renaming a library is a breaking change
-apache-poi = { group = 'org.apache.poi', name = 'poi', version.ref = 'apache-poi' }
-apache-poi-ooxml = { group = 'org.apache.poi', name = 'poi-ooxml', version.ref = 'apache-poi' }
+apache-poi = { group = 'org.apache.poi', name = 'poi', version.ref = 'apachePoi' }
+apache-poi-ooxml = { group = 'org.apache.poi', name = 'poi-ooxml', version.ref = 'apachePoi' }
 
 aws-apache-client = { group = 'software.amazon.awssdk', name = 'apache-client', version.ref = 'awsSdk2' }
 aws-ion = { group = 'com.amazon.ion', name = 'ion-java', version.ref = 'awsIon' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,31 +2,46 @@
 # Renaming a component (library, plugin, or bundle) or upgrading major versions of dependencies
 # is a breaking change and should be reflected in our version number.
 [versions]
+apache-poi = { strictly = '5.4.1' }
 apacheCommons = { require = '3.17.0' }
 apacheHttpClient = { strictly = '5.5' }
+assertj = { strictly = '3.27.3' }
 awsIon = { strictly = '1.11.10' }
 awsLambdaCore = { strictly = '1.3.0' }
 awsLambdaEvents = { strictly = '3.16.0' }
 awsSdk = { strictly = '1.12.787' }
 awsSdk2 = { strictly = '2.31.77' }
-com-auth0-jwt = { strictly = '4.5.0' }
+benManesVersions = { strictly = '0.52.0' }
 com-auth0-jwks = { strictly = '0.22.2' }
+com-auth0-jwt = { strictly = '4.5.0' }
 commonsValidator = { strictly = '1.10.0' }
+cucumber = { strictly = '7.21.1' }
 datafaker = { strictly = '2.4.3' }
+errorprone = { strictly = '2.37.0' }
+errorpronePlugin = { strictly = '4.1.0' }
 guava = { strictly = '33.4.8-jre' }
 hamcrest = { strictly = '3.0' }
 jackson = { strictly = '2.19.1' }
+jena = { strictly = '5.4.0' }
 jupiter = { strictly = '5.13.3' }
 jupiterPlatform = { strictly = '1.13.3' } # Keep minor & patch version in sync with `jupiter`
 lambdaLog4j = { strictly = '1.6.0' }
 log4j = { strictly = '2.25.0' }
 mockito = { strictly = '5.18.0' }
+openCsv = { strictly = '5.11.2' }
+openSearchClient = { strictly = '3.1.0' }
+openSearchTestContainer = { strictly = '3.0.1' }
 slf4j = { strictly = '2.0.17' }
+spotless = { strictly = '7.1.0' }
+testContainers = { strictly = '1.21.3' }
 wiremock = { strictly = '4.0.0-beta.14' }
 zalandoProblem = { strictly = '0.27.1' }
 
 [libraries]
 # IMPORTANT: Renaming a library is a breaking change
+apache-poi = { group = 'org.apache.poi', name = 'poi', version.ref = 'apache-poi' }
+apache-poi-ooxml = { group = 'org.apache.poi', name = 'poi-ooxml', version.ref = 'apache-poi' }
+
 aws-apache-client = { group = 'software.amazon.awssdk', name = 'apache-client', version.ref = 'awsSdk2' }
 aws-ion = { group = 'com.amazon.ion', name = 'ion-java', version.ref = 'awsIon' }
 aws-java-sdk-core = { group = 'com.amazonaws', name = 'aws-java-sdk-core', version.ref = 'awsSdk' }
@@ -41,12 +56,11 @@ aws-sdk2-s3 = { group = 'software.amazon.awssdk', name = 's3', version.ref = 'aw
 aws-sdk2-secrets = { group = 'software.amazon.awssdk', name = 'secretsmanager', version.ref = 'awsSdk2' }
 aws-sdk2-urlconnection = { group = 'software.amazon.awssdk', name = 'url-connection-client', version.ref = 'awsSdk2' }
 
-com-auth0-jwks = { group = 'com.auth0', name =  'jwks-rsa', version.ref= 'com-auth0-jwks' }
+com-auth0-jwks = { group = 'com.auth0', name = 'jwks-rsa', version.ref = 'com-auth0-jwks' }
 com-auth0-jwt = { group = 'com.auth0', name = 'java-jwt', version.ref = 'com-auth0-jwt' }
 commons-lang = { group = 'org.apache.commons', name = 'commons-lang3', version.ref = 'apacheCommons' }
 commons-validator = { group = 'commons-validator', name = 'commons-validator', version.ref = 'commonsValidator' }
 guava = { group = 'com.google.guava', name = 'guava', version.ref = 'guava' }
-
 jackson-annotations = { group = 'com.fasterxml.jackson.core', name = 'jackson-annotations', version.ref = 'jackson' }
 jackson-core = { group = 'com.fasterxml.jackson.core', name = 'jackson-core', version.ref = 'jackson' }
 jackson-databind = { group = 'com.fasterxml.jackson.core', name = 'jackson-databind', version.ref = 'jackson' }
@@ -54,11 +68,16 @@ jackson-dataformat-xml = { group = 'com.fasterxml.jackson.dataformat', name = 'j
 jackson-datatype-jdk8 = { group = 'com.fasterxml.jackson.datatype', name = 'jackson-datatype-jdk8', version.ref = 'jackson' }
 jackson-datatype-jsr310 = { group = 'com.fasterxml.jackson.datatype', name = 'jackson-datatype-jsr310', version.ref = 'jackson' }
 jackson-datatype-problem = { group = 'org.zalando', name = 'jackson-datatype-problem', version.ref = 'zalandoProblem' }
-
 jackson-jr-annotations = { group = 'com.fasterxml.jackson.jr', name = 'jackson-jr-annotation-support', version.ref = 'jackson' }
 jackson-jr-objects = { group = 'com.fasterxml.jackson.jr', name = 'jackson-jr-objects', version.ref = 'jackson' }
 jackson-module-parameter-names = { group = 'com.fasterxml.jackson.module', name = 'jackson-module-parameter-names', version.ref = 'jackson' }
+jena-arq = { group = 'org.apache.jena', name = 'jena-arq', version.ref = 'jena' }
+jena-core = { group = 'org.apache.jena', name = 'jena-core', version.ref = 'jena' }
+openCsv = { group = 'com.opencsv', name = 'opencsv', version.ref = 'openCsv' }
 zalando = { group = 'org.zalando', name = 'problem', version.ref = 'zalandoProblem' }
+
+# Build tools
+errorprone = { group = 'com.google.errorprone', name = 'error_prone_core', version.ref = 'errorprone' }
 
 # Logging dependencies
 lambda-log4j = { group = 'com.amazonaws', name = 'aws-lambda-java-log4j2', version.ref = 'lambdaLog4j' }
@@ -68,6 +87,10 @@ log4j-slf4j-impl = { group = 'org.apache.logging.log4j', name = 'log4j-slf4j2-im
 slf4j-api = { group = 'org.slf4j', name = 'slf4j-api', version.ref = 'slf4j' }
 
 # Test dependencies
+assertj-core = { group = 'org.assertj', name = 'assertj-core', version.ref = 'assertj' }
+cucumber-java = { group = 'io.cucumber', name = 'cucumber-java', version.ref = 'cucumber' }
+cucumber-junit-platform-engine = { group = 'io.cucumber', name = 'cucumber-junit-platform-engine', version.ref = 'cucumber' }
+cucumber-picocontainer = { group = 'io.cucumber', name = 'cucumber-picocontainer', version.ref = 'cucumber' }
 datafaker = { group = 'net.datafaker', name = 'datafaker', version.ref = 'datafaker' }
 hamcrest = { group = 'org.hamcrest', name = 'hamcrest', version.ref = 'hamcrest' }
 hamcrest-core = { group = 'org.hamcrest', name = 'hamcrest-core', version.ref = 'hamcrest' }
@@ -78,19 +101,22 @@ junit-jupiter-engine = { group = 'org.junit.jupiter', name = 'junit-jupiter-engi
 junit-jupiter-params = { group = 'org.junit.jupiter', name = 'junit-jupiter-params', version.ref = 'jupiter' }
 junit-platform-launcher = { group = 'org.junit.platform', name = 'junit-platform-launcher', version.ref = 'jupiterPlatform' }
 mockito-core = { group = 'org.mockito', name = 'mockito-core', version.ref = 'mockito' }
+opensearch-java = { group = 'org.opensearch.client', name = 'opensearch-java', version.ref = 'openSearchClient' }
+opensearch-rest-client = { group = 'org.opensearch.client', name = 'opensearch-rest-client', version.ref = 'openSearchClient' }
+testContainers = { group = 'org.testcontainers', name = 'testcontainers', version.ref = 'testContainers' }
+testContainersJunit = { group = 'org.testcontainers', name = 'junit-jupiter', version.ref = 'testContainers' }
+testContainersOpenSearch = { group = 'org.opensearch', name = 'opensearch-testcontainers', version.ref = 'openSearchTestContainer' }
 wiremock = { group = 'org.wiremock', name = 'wiremock', version.ref = 'wiremock' }
+
+[plugins]
+# IMPORTANT: Renaming or removing a plugin is a breaking change
+errorprone = { id = "net.ltgt.errorprone", version.ref = 'errorpronePlugin' }
+gradle-versions = { id = "com.github.ben-manes.versions", version.ref = 'benManesVersions' }
+spotless = { id = "com.diffplug.spotless", version.ref = 'spotless' }
 
 [bundles]
 # IMPORTANT: Renaming a bundle or removing elements from it is a breaking change
-testing-junit = [
-    'junit-jupiter',
-    'junit-jupiter-api', 
-    'junit-jupiter-engine',
-    'junit-jupiter-params',
-    'junit-platform-launcher'
-]
-testing-mockito = ['mockito-core']
-testing-hamcrest = ['hamcrest', 'hamcrest-core']
+apachePoi = ['apache-poi', 'apache-poi-ooxml']
 jackson = [
     'jackson-annotations',
     'jackson-core',
@@ -99,14 +125,23 @@ jackson = [
     'jackson-datatype-jdk8',
     'jackson-datatype-jsr310',
     'jackson-datatype-problem',
-    'jackson-module-parameter-names'
-]
+    'jackson-module-parameter-names']
 jacksonjr = ['jackson-jr-objects', 'jackson-jr-annotations']
+jena = ['jena-core', 'jena-arq']
 logging = [
     'lambda-log4j',
     'log4j-api',
     'log4j-core',
     'log4j-slf4j-impl',
-    'slf4j-api'
-]
+    'slf4j-api']
 
+testing-cucumber = ['cucumber-java', 'cucumber-junit-platform-engine', 'cucumber-picocontainer']
+testing-hamcrest = ['hamcrest', 'hamcrest-core']
+testing-junit = [
+    'junit-jupiter',
+    'junit-jupiter-api',
+    'junit-jupiter-engine',
+    'junit-jupiter-params',
+    'junit-platform-launcher']
+testing-mockito = ['mockito-core']
+testing-testcontainers = ['testContainers', 'testContainersJunit', 'testContainersOpenSearch']

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,64 +2,62 @@
 # Renaming a component (library, plugin, or bundle) or upgrading major versions of dependencies
 # is a breaking change and should be reflected in our version number.
 [versions]
-apacheCommons = { require = '3.17.0' }
-apacheHttpClient = { strictly = '5.5' }
-apachePoi = { strictly = '5.4.1' }
+apache-commons = { require = '3.17.0' }
+apache-http-client = { strictly = '5.5' }
+apache-poi = { strictly = '5.4.1' }
 assertj = { strictly = '3.27.3' }
-awsIon = { strictly = '1.11.10' }
-awsLambdaCore = { strictly = '1.3.0' }
-awsLambdaEvents = { strictly = '3.16.0' }
-awsSdk = { strictly = '1.12.787' }
-awsSdk2 = { strictly = '2.31.77' }
-benManesVersions = { strictly = '0.52.0' }
+aws-ion = { strictly = '1.11.10' }
+aws-lambda-core = { strictly = '1.3.0' }
+aws-lambda-events = { strictly = '3.16.0' }
+aws-sdk = { strictly = '1.12.787' }
+aws-sdk2 = { strictly = '2.31.77' }
+ben-manes-versions = { strictly = '0.52.0' }
 com-auth0-jwks = { strictly = '0.22.2' }
 com-auth0-jwt = { strictly = '4.5.0' }
-commonsValidator = { strictly = '1.10.0' }
+commons-validator = { strictly = '1.10.0' }
 cucumber = { strictly = '7.21.1' }
 datafaker = { strictly = '2.4.3' }
 errorprone = { strictly = '2.37.0' }
-errorpronePlugin = { strictly = '4.1.0' }
+errorprone-plugin = { strictly = '4.1.0' }
 guava = { strictly = '33.4.8-jre' }
 hamcrest = { strictly = '3.0' }
 jackson = { strictly = '2.19.1' }
 jena = { strictly = '5.4.0' }
 jupiter = { strictly = '5.13.3' }
-jupiterPlatform = { strictly = '1.13.3' } # Keep minor & patch version in sync with `jupiter`
-lambdaLog4j = { strictly = '1.6.0' }
+jupiter-platform = { strictly = '1.13.3' } # Keep minor & patch version in sync with `jupiter`
+lambda-log4j = { strictly = '1.6.0' }
 log4j = { strictly = '2.25.0' }
 mockito = { strictly = '5.18.0' }
-openCsv = { strictly = '5.11.2' }
-openSearchClient = { strictly = '3.1.0' }
-openSearchTestContainer = { strictly = '3.0.1' }
+opencsv = { strictly = '5.11.2' }
+opensearch-client = { strictly = '3.1.0' }
+opensearch-testcontainer = { strictly = '3.0.1' }
 slf4j = { strictly = '2.0.17' }
 spotless = { strictly = '7.1.0' }
-testContainers = { strictly = '1.21.3' }
+testcontainers = { strictly = '1.21.3' }
 wiremock = { strictly = '4.0.0-beta.14' }
-zalandoProblem = { strictly = '0.27.1' }
+zalando-problem = { strictly = '0.27.1' }
 
 [libraries]
 # IMPORTANT: Renaming a library is a breaking change
-apache-poi = { group = 'org.apache.poi', name = 'poi', version.ref = 'apachePoi' }
-apache-poi-ooxml = { group = 'org.apache.poi', name = 'poi-ooxml', version.ref = 'apachePoi' }
-
-aws-apache-client = { group = 'software.amazon.awssdk', name = 'apache-client', version.ref = 'awsSdk2' }
-aws-ion = { group = 'com.amazon.ion', name = 'ion-java', version.ref = 'awsIon' }
-aws-java-sdk-core = { group = 'com.amazonaws', name = 'aws-java-sdk-core', version.ref = 'awsSdk' }
-aws-lambda-core = { group = 'com.amazonaws', name = 'aws-lambda-java-core', version.ref = 'awsLambdaCore' }
-aws-lambda-events = { group = 'com.amazonaws', name = 'aws-lambda-java-events', version.ref = 'awsLambdaEvents' }
-aws-sdk-dynamo = { group = 'com.amazonaws', name = 'aws-java-sdk-dynamodb', version.ref = 'awsSdk' }
-aws-sdk2-core = { group = 'software.amazon.awssdk', name = 'sdk-core', version.ref = 'awsSdk2' }
-aws-sdk2-dynamo = { group = 'software.amazon.awssdk', name = 'dynamodb', version.ref = 'awsSdk2' }
-aws-sdk2-eventbridge = { group = 'software.amazon.awssdk', name = 'eventbridge', version.ref = 'awsSdk2' }
-aws-sdk2-firehose = { group = 'software.amazon.awssdk', name = 'firehose', version.ref = 'awsSdk2' }
-aws-sdk2-s3 = { group = 'software.amazon.awssdk', name = 's3', version.ref = 'awsSdk2' }
-aws-sdk2-secrets = { group = 'software.amazon.awssdk', name = 'secretsmanager', version.ref = 'awsSdk2' }
-aws-sdk2-urlconnection = { group = 'software.amazon.awssdk', name = 'url-connection-client', version.ref = 'awsSdk2' }
-
+apache-poi = { group = 'org.apache.poi', name = 'poi', version.ref = 'apache-poi' }
+apache-poi-ooxml = { group = 'org.apache.poi', name = 'poi-ooxml', version.ref = 'apache-poi' }
+aws-apache-client = { group = 'software.amazon.awssdk', name = 'apache-client', version.ref = 'aws-sdk2' }
+aws-ion = { group = 'com.amazon.ion', name = 'ion-java', version.ref = 'aws-ion' }
+aws-java-sdk-core = { group = 'com.amazonaws', name = 'aws-java-sdk-core', version.ref = 'aws-sdk' }
+aws-lambda-core = { group = 'com.amazonaws', name = 'aws-lambda-java-core', version.ref = 'aws-lambda-core' }
+aws-lambda-events = { group = 'com.amazonaws', name = 'aws-lambda-java-events', version.ref = 'aws-lambda-events' }
+aws-sdk-dynamo = { group = 'com.amazonaws', name = 'aws-java-sdk-dynamodb', version.ref = 'aws-sdk' }
+aws-sdk2-core = { group = 'software.amazon.awssdk', name = 'sdk-core', version.ref = 'aws-sdk2' }
+aws-sdk2-dynamo = { group = 'software.amazon.awssdk', name = 'dynamodb', version.ref = 'aws-sdk2' }
+aws-sdk2-eventbridge = { group = 'software.amazon.awssdk', name = 'eventbridge', version.ref = 'aws-sdk2' }
+aws-sdk2-firehose = { group = 'software.amazon.awssdk', name = 'firehose', version.ref = 'aws-sdk2' }
+aws-sdk2-s3 = { group = 'software.amazon.awssdk', name = 's3', version.ref = 'aws-sdk2' }
+aws-sdk2-secrets = { group = 'software.amazon.awssdk', name = 'secretsmanager', version.ref = 'aws-sdk2' }
+aws-sdk2-urlconnection = { group = 'software.amazon.awssdk', name = 'url-connection-client', version.ref = 'aws-sdk2' }
 com-auth0-jwks = { group = 'com.auth0', name = 'jwks-rsa', version.ref = 'com-auth0-jwks' }
 com-auth0-jwt = { group = 'com.auth0', name = 'java-jwt', version.ref = 'com-auth0-jwt' }
-commons-lang = { group = 'org.apache.commons', name = 'commons-lang3', version.ref = 'apacheCommons' }
-commons-validator = { group = 'commons-validator', name = 'commons-validator', version.ref = 'commonsValidator' }
+commons-lang = { group = 'org.apache.commons', name = 'commons-lang3', version.ref = 'apache-commons' }
+commons-validator = { group = 'commons-validator', name = 'commons-validator', version.ref = 'commons-validator' }
 guava = { group = 'com.google.guava', name = 'guava', version.ref = 'guava' }
 jackson-annotations = { group = 'com.fasterxml.jackson.core', name = 'jackson-annotations', version.ref = 'jackson' }
 jackson-core = { group = 'com.fasterxml.jackson.core', name = 'jackson-core', version.ref = 'jackson' }
@@ -67,20 +65,20 @@ jackson-databind = { group = 'com.fasterxml.jackson.core', name = 'jackson-datab
 jackson-dataformat-xml = { group = 'com.fasterxml.jackson.dataformat', name = 'jackson-dataformat-xml', version.ref = 'jackson' }
 jackson-datatype-jdk8 = { group = 'com.fasterxml.jackson.datatype', name = 'jackson-datatype-jdk8', version.ref = 'jackson' }
 jackson-datatype-jsr310 = { group = 'com.fasterxml.jackson.datatype', name = 'jackson-datatype-jsr310', version.ref = 'jackson' }
-jackson-datatype-problem = { group = 'org.zalando', name = 'jackson-datatype-problem', version.ref = 'zalandoProblem' }
+jackson-datatype-problem = { group = 'org.zalando', name = 'jackson-datatype-problem', version.ref = 'zalando-problem' }
 jackson-jr-annotations = { group = 'com.fasterxml.jackson.jr', name = 'jackson-jr-annotation-support', version.ref = 'jackson' }
 jackson-jr-objects = { group = 'com.fasterxml.jackson.jr', name = 'jackson-jr-objects', version.ref = 'jackson' }
 jackson-module-parameter-names = { group = 'com.fasterxml.jackson.module', name = 'jackson-module-parameter-names', version.ref = 'jackson' }
 jena-arq = { group = 'org.apache.jena', name = 'jena-arq', version.ref = 'jena' }
 jena-core = { group = 'org.apache.jena', name = 'jena-core', version.ref = 'jena' }
-openCsv = { group = 'com.opencsv', name = 'opencsv', version.ref = 'openCsv' }
-zalando = { group = 'org.zalando', name = 'problem', version.ref = 'zalandoProblem' }
+opencsv = { group = 'com.opencsv', name = 'opencsv', version.ref = 'opencsv' }
+zalando = { group = 'org.zalando', name = 'problem', version.ref = 'zalando-problem' }
 
 # Build tools
 errorprone = { group = 'com.google.errorprone', name = 'error_prone_core', version.ref = 'errorprone' }
 
 # Logging dependencies
-lambda-log4j = { group = 'com.amazonaws', name = 'aws-lambda-java-log4j2', version.ref = 'lambdaLog4j' }
+lambda-log4j = { group = 'com.amazonaws', name = 'aws-lambda-java-log4j2', version.ref = 'lambda-log4j' }
 log4j-api = { group = 'org.apache.logging.log4j', name = 'log4j-api', version.ref = 'log4j' }
 log4j-core = { group = 'org.apache.logging.log4j', name = 'log4j-core', version.ref = 'log4j' }
 log4j-slf4j-impl = { group = 'org.apache.logging.log4j', name = 'log4j-slf4j2-impl', version.ref = 'log4j' }
@@ -94,29 +92,29 @@ cucumber-picocontainer = { group = 'io.cucumber', name = 'cucumber-picocontainer
 datafaker = { group = 'net.datafaker', name = 'datafaker', version.ref = 'datafaker' }
 hamcrest = { group = 'org.hamcrest', name = 'hamcrest', version.ref = 'hamcrest' }
 hamcrest-core = { group = 'org.hamcrest', name = 'hamcrest-core', version.ref = 'hamcrest' }
-httpclient5 = { group = 'org.apache.httpcomponents.client5', name = 'httpclient5', version.ref = 'apacheHttpClient' }
+httpclient5 = { group = 'org.apache.httpcomponents.client5', name = 'httpclient5', version.ref = 'apache-http-client' }
 junit-jupiter = { group = 'org.junit.jupiter', name = 'junit-jupiter', version.ref = 'jupiter' }
 junit-jupiter-api = { group = 'org.junit.jupiter', name = 'junit-jupiter-api', version.ref = 'jupiter' }
 junit-jupiter-engine = { group = 'org.junit.jupiter', name = 'junit-jupiter-engine', version.ref = 'jupiter' }
 junit-jupiter-params = { group = 'org.junit.jupiter', name = 'junit-jupiter-params', version.ref = 'jupiter' }
-junit-platform-launcher = { group = 'org.junit.platform', name = 'junit-platform-launcher', version.ref = 'jupiterPlatform' }
+junit-platform-launcher = { group = 'org.junit.platform', name = 'junit-platform-launcher', version.ref = 'jupiter-platform' }
 mockito-core = { group = 'org.mockito', name = 'mockito-core', version.ref = 'mockito' }
-opensearch-java = { group = 'org.opensearch.client', name = 'opensearch-java', version.ref = 'openSearchClient' }
-opensearch-rest-client = { group = 'org.opensearch.client', name = 'opensearch-rest-client', version.ref = 'openSearchClient' }
-testContainers = { group = 'org.testcontainers', name = 'testcontainers', version.ref = 'testContainers' }
-testContainersJunit = { group = 'org.testcontainers', name = 'junit-jupiter', version.ref = 'testContainers' }
-testContainersOpenSearch = { group = 'org.opensearch', name = 'opensearch-testcontainers', version.ref = 'openSearchTestContainer' }
+opensearch-java = { group = 'org.opensearch.client', name = 'opensearch-java', version.ref = 'opensearch-client' }
+opensearch-rest-client = { group = 'org.opensearch.client', name = 'opensearch-rest-client', version.ref = 'opensearch-client' }
+testcontainers = { group = 'org.testcontainers', name = 'testcontainers', version.ref = 'testcontainers' }
+testcontainers-junit = { group = 'org.testcontainers', name = 'junit-jupiter', version.ref = 'testcontainers' }
+testcontainers-opensearch = { group = 'org.opensearch', name = 'opensearch-testcontainers', version.ref = 'opensearch-testcontainer' }
 wiremock = { group = 'org.wiremock', name = 'wiremock', version.ref = 'wiremock' }
 
 [plugins]
 # IMPORTANT: Renaming or removing a plugin is a breaking change
-errorprone = { id = "net.ltgt.errorprone", version.ref = 'errorpronePlugin' }
-gradle-versions = { id = "com.github.ben-manes.versions", version.ref = 'benManesVersions' }
+errorprone = { id = "net.ltgt.errorprone", version.ref = 'errorprone-plugin' }
+gradle-versions = { id = "com.github.ben-manes.versions", version.ref = 'ben-manes-versions' }
 spotless = { id = "com.diffplug.spotless", version.ref = 'spotless' }
 
 [bundles]
 # IMPORTANT: Renaming a bundle or removing elements from it is a breaking change
-apachePoi = ['apache-poi', 'apache-poi-ooxml']
+apache-poi = ['apache-poi', 'apache-poi-ooxml']
 jackson = [
     'jackson-annotations',
     'jackson-core',
@@ -144,4 +142,4 @@ testing-junit = [
     'junit-jupiter-params',
     'junit-platform-launcher']
 testing-mockito = ['mockito-core']
-testing-testcontainers = ['testContainers', 'testContainersJunit', 'testContainersOpenSearch']
+testing-testcontainers = ['testcontainers', 'testcontainers-junit', 'testcontainers-opensearch']


### PR DESCRIPTION
Convert all identifiers in `libs.versions.toml` to `kebab-case` in order to be consistent.

Note: This may be a breaking change for consumers that reference the version catalog.