### PR TITLE
feat: Add convention plugins

### DIFF
--- a/build-logic/README.md
+++ b/build-logic/README.md
@@ -1,0 +1,102 @@
+# Build Logic
+
+This subproject contains Gradle convention plugins that centralize common build configuration 
+for the NVA project. These are published as artifacts to Maven Central alongside the Java 
+libraries in this repository.
+
+## Convention Plugins
+
+The core concept is to bundle relevant Gradle configuration into "convention" plugins.
+These can be split up further without requiring changes from consumers, as long as the main 
+plugin IDs stay the same.
+
+### `nva.root-module-conventions`
+
+Configuration and utilities specific to the root project:
+
+- Aggregates code coverage reports from all subprojects
+- Enforces 100% test coverage on method and class level
+- Custom tasks for convenience:
+    - `verifyCoverage`: Verifies aggregated coverage meets requirements
+    - `showCoverageReport`: Displays clickable link to coverage report
+    - `dependencyUpdates`: Shows available dependency updates
+
+Applied only in the root project's `build.gradle`.
+
+### `nva.java-conventions`
+
+Standard Java project configuration for all NVA Commons modules:
+
+- Sets up Java toolchain with Amazon Corretto vendor
+- Configures quality tools: PMD, Jacoco, ErrorProne
+- Applies formatting conventions
+- Sets up testing with JUnit platform
+- Configures code coverage reporting
+
+Applied directly in each Java module's `build.gradle`:
+
+```groovy
+plugins {
+    id 'nva.java-conventions'
+    id 'nvacommons.publish-maven'
+}
+```
+
+### `nva.formatting-conventions`
+
+Provides consistent code formatting using Spotless:
+
+- Java code formatting with Google Java Format
+- Groovy Gradle script formatting
+- Formatting for miscellaneous files (`.gitignore`, `.gitattributes`, `.editorconfig`, `*.md`)
+- Automatically applies formatting during `build` and `test` tasks
+- Supports `spotless:off` / `spotless:on` toggle comments
+
+Applied automatically by either `nva.java-conventions` or `nva.root-module-conventions` plugins.
+
+## Project Structure
+
+```
+build-logic/
+├── build.gradle              # Plugin configuration and dependencies
+├── settings.gradle           # Project settings
+├── src/main/groovy/          # Convention plugins to be published
+├── src/main/resources/       # Plugin resources
+│   └── pmd-ruleset.xml       # PMD rules bundled with the plugin
+└── README.md                 # This file
+```
+
+## How It Works
+
+1. **Plugin Compilation**: Gradle compiles the `.gradle` files in `src/main/groovy/` into proper 
+   Gradle plugins
+2. **Plugin Registration**: Each `.gradle` file becomes a plugin with an ID matching its filename
+3. **Plugin Application**: Other subprojects apply these plugins using the standard `plugins {}` 
+   block
+
+## Usage in Other Projects
+
+To use these convention plugins in other NVA projects:
+
+1. Include the build-logic dependency in your `buildSrc` or `build.gradle`
+2. Apply the relevant convention plugins:
+   ```groovy
+   plugins {
+       id 'nva.java-conventions'
+       // other plugins...
+   }
+   ```
+
+## Customization
+
+To modify shared build logic:
+
+1. Edit the relevant `.gradle` file in `src/main/groovy/`
+2. The changes will automatically apply to all projects using that convention plugin
+3. Test changes by running `./gradlew build` from the root project
+
+## PMD Ruleset
+
+The `nva.java-conventions` plugin bundles a customized PMD ruleset (`pmd-ruleset.xml`) that enforces
+NVA coding standards. To modify PMD rules for all projects, edit
+`src/main/resources/pmd-ruleset.xml` in the build-logic project.

--- a/build-logic/README.md
+++ b/build-logic/README.md
@@ -1,13 +1,13 @@
 # Build Logic
 
-This subproject contains Gradle convention plugins that centralize common build configuration 
-for the NVA project. These are published as artifacts to Maven Central alongside the Java 
+This subproject contains Gradle convention plugins that centralize common build configuration
+for the NVA project. These are published as artifacts to Maven Central alongside the Java
 libraries in this repository.
 
 ## Convention Plugins
 
 The core concept is to bundle relevant Gradle configuration into "convention" plugins.
-These can be split up further without requiring changes from consumers, as long as the main 
+These can be split up further without requiring changes from consumers, as long as the main
 plugin IDs stay the same.
 
 ### `nva.root-module-conventions`
@@ -68,24 +68,16 @@ build-logic/
 
 ## How It Works
 
-1. **Plugin Compilation**: Gradle compiles the `.gradle` files in `src/main/groovy/` into proper 
+1. **Plugin Compilation**: Gradle compiles the `.gradle` files in `src/main/groovy/` into proper
    Gradle plugins
 2. **Plugin Registration**: Each `.gradle` file becomes a plugin with an ID matching its filename
-3. **Plugin Application**: Other subprojects apply these plugins using the standard `plugins {}` 
+3. **Plugin Application**: Other subprojects apply these plugins using the standard `plugins {}`
    block
 
 ## Usage in Other Projects
 
-To use these convention plugins in other NVA projects:
-
-1. Include the build-logic dependency in your `buildSrc` or `build.gradle`
-2. Apply the relevant convention plugins:
-   ```groovy
-   plugins {
-       id 'nva.java-conventions'
-       // other plugins...
-   }
-   ```
+See our [example repository](https://github.com/BIBSYSDEV/nva-gradle-template) for a complete
+example on how to use these convention plugins.
 
 ## Customization
 

--- a/build-logic/README.md
+++ b/build-logic/README.md
@@ -38,7 +38,6 @@ Applied directly in each Java module's `build.gradle`:
 ```groovy
 plugins {
     id 'nva.java-conventions'
-    id 'nvacommons.publish-maven'
 }
 ```
 

--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -3,6 +3,15 @@ plugins {
     id 'nvacommons.publish-artifact'
 }
 
-repositories {
-    gradlePluginPortal()
+// Helper to turn a version‑catalog plugin alias into marker‑artifact coordinates <id>:<id>.gradle.plugin:<version>
+def pluginNotation = { Provider<PluginDependency> plugin ->
+    plugin.map {
+        "${it.pluginId}:${it.pluginId}.gradle.plugin:${it.version.getStrictVersion()}"
+    }
+}
+
+dependencies {
+    implementation(pluginNotation(libs.plugins.spotless))
+    implementation(pluginNotation(libs.plugins.errorprone))
+    implementation(pluginNotation(libs.plugins.gradle.versions))
 }

--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'groovy-gradle-plugin'
+    id 'nvacommons.publish-artifact'
+}
+
+repositories {
+    gradlePluginPortal()
+}

--- a/build-logic/settings.gradle
+++ b/build-logic/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'build-logic'

--- a/build-logic/settings.gradle
+++ b/build-logic/settings.gradle
@@ -1,1 +1,9 @@
 rootProject.name = 'build-logic'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/build-logic/src/main/groovy/nva.formatting-conventions.gradle
+++ b/build-logic/src/main/groovy/nva.formatting-conventions.gradle
@@ -1,0 +1,35 @@
+plugins {
+    id 'com.diffplug.spotless'
+}
+
+spotless {
+    if (plugins.hasPlugin('java')) {
+        java {
+            toggleOffOn() // Ignores sections between `spotless:off` / `spotless:on`
+            googleJavaFormat().reflowLongStrings().formatJavadoc(true).reorderImports(true)
+        }
+    }
+
+    groovyGradle {
+        target '**/*.gradle'
+        greclipse()
+        leadingTabsToSpaces(4)
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+
+    format 'misc', {
+        target '.gitignore', '.gitattributes', '.editorconfig', '**/*.md'
+        leadingTabsToSpaces(4)
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
+tasks.named('build').configure {
+    dependsOn('spotlessApply')
+}
+
+tasks.matching { it.name == 'test' }.configureEach {
+    dependsOn('spotlessApply')
+}

--- a/build-logic/src/main/groovy/nva.java-conventions.gradle
+++ b/build-logic/src/main/groovy/nva.java-conventions.gradle
@@ -21,7 +21,7 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 pmd {
-    toolVersion = '7.14.0'
+    toolVersion = '7.15.0'
     ruleSetFiles = files(resources.text.fromString(getClass().getResourceAsStream('/pmd-ruleset.xml').text))
     ruleSets = []
     ignoreFailures = false

--- a/build-logic/src/main/groovy/nva.java-conventions.gradle
+++ b/build-logic/src/main/groovy/nva.java-conventions.gradle
@@ -1,0 +1,49 @@
+plugins {
+    id 'java-library'
+    id 'nva.formatting-conventions'
+    id 'jacoco'
+    id 'pmd'
+    id 'net.ltgt.errorprone'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+        vendor = JvmVendorSpec.AMAZON
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+        // Suppress build failures from lint errors (remove this if possible)
+        allErrorsAsWarnings = true
+    }
+}
+
+pmd {
+    toolVersion = '7.14.0'
+    ruleSetFiles = files(resources.text.fromString(getClass().getResourceAsStream('/pmd-ruleset.xml').text))
+    ruleSets = []
+    ignoreFailures = false
+}
+
+tasks.named('test', Test) {
+    useJUnitPlatform()
+    failFast = false
+    testLogging {
+        events = ['skipped', 'passed', 'failed']
+        showCauses = true
+        exceptionFormat = "full"
+    }
+}
+
+tasks.named("jacocoTestReport", JacocoReport) {
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('test')
+}

--- a/build-logic/src/main/groovy/nva.root-module-conventions.gradle
+++ b/build-logic/src/main/groovy/nva.root-module-conventions.gradle
@@ -76,7 +76,7 @@ tasks.named('verifyCoverage') {
 def isNonStable(String version) {
     def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { version.toUpperCase().contains(it) }
 
-    // Stable version patterns: digits/dots/v/hyphens optionally ending with -r/-jre/-android
+    // Stable version patterns: digits/dots/v/hyphens optionally ending with -r/-jre
     def stableVersionPattern = /^[0-9,.v-]+(-r|-jre)?$/
     return !stableKeyword && !(version ==~ stableVersionPattern)
 }

--- a/build-logic/src/main/groovy/nva.root-module-conventions.gradle
+++ b/build-logic/src/main/groovy/nva.root-module-conventions.gradle
@@ -1,0 +1,93 @@
+plugins {
+    id 'base'
+    id 'jacoco-report-aggregation'
+    id 'nva.formatting-conventions'
+    id 'com.github.ben-manes.versions'
+}
+
+dependencies {
+    // Automatically aggregate coverage from all subprojects
+    subprojects.each { subproject ->
+        jacocoAggregation subproject
+    }
+}
+
+reporting {
+    reports {
+        testCodeCoverageReport(JacocoCoverageReport) {
+            testSuiteName = 'test'
+        }
+    }
+}
+
+tasks.register('verifyCoverage', JacocoCoverageVerification) {
+    group = "test coverage"
+    description = "Verify test coverage"
+    dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
+
+    // Get data from the aggregated report task
+    def reportTask = tasks.named('testCodeCoverageReport')
+    executionData = reportTask.get().executionData
+    sourceDirectories = reportTask.get().sourceDirectories
+    classDirectories = reportTask.get().classDirectories
+
+    violationRules {
+        rule {
+            limit {
+                counter = 'METHOD'
+                value = 'COVEREDRATIO'
+                minimum = 1.000
+            }
+        }
+
+        rule {
+            limit {
+                counter = 'CLASS'
+                value = 'COVEREDRATIO'
+                minimum = 1.000
+            }
+        }
+    }
+}
+
+tasks.register('showCoverageReport') {
+    group = "test coverage"
+    description = "Show clickable link to test coverage report"
+    dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
+    outputs.upToDateWhen { false }
+
+    doLast {
+        def reportDirPath = "reports/jacoco/testCodeCoverageReport/html"
+        def reportDir = layout.buildDirectory.dir(reportDirPath).get().asFile
+        logger.quiet("Combined coverage report:")
+        logger.quiet("file://${reportDir}/index.html")
+    }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('verifyCoverage', JacocoCoverageVerification)
+    finalizedBy tasks.named('showCoverageReport')
+}
+
+tasks.named('verifyCoverage') {
+    finalizedBy tasks.named('showCoverageReport')
+}
+
+def isNonStable(String version) {
+    def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { version.toUpperCase().contains(it) }
+
+    // Stable version patterns: digits/dots/v/hyphens optionally ending with -r/-jre/-android
+    def stableVersionPattern = /^[0-9,.v-]+(-r|-jre)?$/
+    return !stableKeyword && !(version ==~ stableVersionPattern)
+}
+
+tasks.named('dependencyUpdates') {
+    checkForGradleUpdate = true
+    outputDir = 'build/dependencyUpdates'
+    reportfileName = 'report'
+    gradleReleaseChannel='current'
+    rejectVersionIf {
+        // Don't suggest upgrading from a stable version to a non-stable version
+        isNonStable(it.candidate.version) && !isNonStable(it.currentVersion)
+    }
+}

--- a/build-logic/src/main/resources/pmd-ruleset.xml
+++ b/build-logic/src/main/resources/pmd-ruleset.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+
+<ruleset name="Custom PMD rules"
+  xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  <description>
+    Custom rules for static analysis with PMD.
+  </description>
+
+  <rule ref="category/java/errorprone.xml">
+    <exclude name="MissingSerialVersionUID"/>
+  </rule>
+
+  <rule ref="category/java/bestpractices.xml">
+    <exclude name="UnitTestAssertionsShouldIncludeMessage"/>
+
+    <!-- Disabled because Cristin IDs are misinterpreted as IPs -->
+    <exclude name="AvoidUsingHardCodedIP"/>
+  </rule>
+
+  <rule ref="category/java/codestyle.xml">
+    <exclude name="AtLeastOneConstructor"/>
+    <exclude name="TooManyStaticImports"/>
+    <exclude name="LongVariable"/>
+    <exclude name="ShortVariable"/>
+    <exclude name="LocalVariableCouldBeFinal"/>
+    <exclude name="MethodArgumentCouldBeFinal"/>
+    <exclude name="UseExplicitTypes"/>
+  </rule>
+
+  <rule ref="category/java/design.xml">
+    <exclude name="LoosePackageCoupling"/>
+    <exclude name="DataClass"/>
+    <exclude name="ExcessiveImports"/>
+    <exclude name="AvoidCatchingGenericException"/>
+    <exclude name="SignatureDeclareThrowsException"/>
+    <exclude name="UseUtilityClass"/>
+    <exclude name="UseObjectForClearerAPI"/>
+    <exclude name="TooManyMethods"/>
+  </rule>
+
+</ruleset>

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.gradle.versions)
 }
 
-allprojects{
-    apply plugin: 'nvacommons.java-conventions'
+allprojects {
+    group = project.property('GROUP')
+    version = project.property('VERSION_NAME')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,11 @@ plugins {
     alias(libs.plugins.gradle.versions)
 }
 
+repositories {
+    gradlePluginPortal()
+    mavenCentral()
+}
+
 allprojects {
     group = project.property('GROUP')
     version = project.property('VERSION_NAME')

--- a/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.java-conventions.gradle
@@ -8,10 +8,6 @@ plugins {
     id 'idea'
 }
 
-
-group = 'com.github.bibsysdev'
-version = '2.3.5'
-
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)

--- a/buildSrc/src/main/groovy/nvacommons.root.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.root.gradle
@@ -6,11 +6,6 @@ plugins {
     id 'com.github.ben-manes.versions'
 }
 
-//workaround for jacoco-merge to work
-allprojects {
-    apply plugin: 'nvacommons.java-conventions'
-}
-
 nexusPublishing {
     repositories {
         sonatype {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.console=verbose
 org.gradle.warning.mode=all
+
+# Shared group and version number for all artifacts generated in this project
+GROUP=com.github.bibsysdev
+VERSION_NAME=2.3.6

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ apache-commons = { require = '3.18.0' }
 apache-http-client = { strictly = '5.5' }
 apache-poi = { strictly = '5.4.1' }
 assertj = { strictly = '3.27.3' }
+aws-ddb-local = { strictly = '2.6.1' }
 aws-ion = { strictly = '1.11.10' }
 aws-lambda-core = { strictly = '1.3.0' }
 aws-lambda-events = { strictly = '3.16.0' }
@@ -59,6 +60,7 @@ com-auth0-jwks = { group = 'com.auth0', name = 'jwks-rsa', version.ref = 'com-au
 com-auth0-jwt = { group = 'com.auth0', name = 'java-jwt', version.ref = 'com-auth0-jwt' }
 commons-lang = { group = 'org.apache.commons', name = 'commons-lang3', version.ref = 'apache-commons' }
 commons-validator = { group = 'commons-validator', name = 'commons-validator', version.ref = 'commons-validator' }
+dynamodDbLocal = { group = 'com.amazonaws', name = 'DynamoDBLocal', version.ref = 'aws-ddb-local' }
 guava = { group = 'com.google.guava', name = 'guava', version.ref = 'guava' }
 jackson-annotations = { group = 'com.fasterxml.jackson.core', name = 'jackson-annotations', version.ref = 'jackson' }
 jackson-core = { group = 'com.fasterxml.jackson.core', name = 'jackson-core', version.ref = 'jackson' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,6 +68,7 @@ guava = { group = 'com.google.guava', name = 'guava', version.ref = 'guava' }
 jackson-annotations = { group = 'com.fasterxml.jackson.core', name = 'jackson-annotations', version.ref = 'jackson' }
 jackson-core = { group = 'com.fasterxml.jackson.core', name = 'jackson-core', version.ref = 'jackson' }
 jackson-databind = { group = 'com.fasterxml.jackson.core', name = 'jackson-databind', version.ref = 'jackson' }
+jackson-dataformat-csv = { group = 'com.fasterxml.jackson.dataformat', name = 'jackson-dataformat-csv', version.ref = 'jackson' }
 jackson-dataformat-xml = { group = 'com.fasterxml.jackson.dataformat', name = 'jackson-dataformat-xml', version.ref = 'jackson' }
 jackson-datatype-jdk8 = { group = 'com.fasterxml.jackson.datatype', name = 'jackson-datatype-jdk8', version.ref = 'jackson' }
 jackson-datatype-jsr310 = { group = 'com.fasterxml.jackson.datatype', name = 'jackson-datatype-jsr310', version.ref = 'jackson' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ zalando-problem = { strictly = '0.27.1' }
 apache-poi = { group = 'org.apache.poi', name = 'poi', version.ref = 'apache-poi' }
 apache-poi-ooxml = { group = 'org.apache.poi', name = 'poi-ooxml', version.ref = 'apache-poi' }
 aws-apache-client = { group = 'software.amazon.awssdk', name = 'apache-client', version.ref = 'aws-sdk2' }
+aws-dynamodb-local = { group = 'com.amazonaws', name = 'DynamoDBLocal', version.ref = 'aws-ddb-local' }
 aws-ion = { group = 'com.amazon.ion', name = 'ion-java', version.ref = 'aws-ion' }
 aws-java-sdk-core = { group = 'com.amazonaws', name = 'aws-java-sdk-core', version.ref = 'aws-sdk' }
 aws-lambda-core = { group = 'com.amazonaws', name = 'aws-lambda-java-core', version.ref = 'aws-lambda-core' }
@@ -63,7 +64,6 @@ com-auth0-jwks = { group = 'com.auth0', name = 'jwks-rsa', version.ref = 'com-au
 com-auth0-jwt = { group = 'com.auth0', name = 'java-jwt', version.ref = 'com-auth0-jwt' }
 commons-lang = { group = 'org.apache.commons', name = 'commons-lang3', version.ref = 'apache-commons' }
 commons-validator = { group = 'commons-validator', name = 'commons-validator', version.ref = 'commons-validator' }
-dynamodDbLocal = { group = 'com.amazonaws', name = 'DynamoDBLocal', version.ref = 'aws-ddb-local' }
 guava = { group = 'com.google.guava', name = 'guava', version.ref = 'guava' }
 jackson-annotations = { group = 'com.fasterxml.jackson.core', name = 'jackson-annotations', version.ref = 'jackson' }
 jackson-core = { group = 'com.fasterxml.jackson.core', name = 'jackson-core', version.ref = 'jackson' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ aws-lambda-events = { group = 'com.amazonaws', name = 'aws-lambda-java-events', 
 aws-sdk-dynamo = { group = 'com.amazonaws', name = 'aws-java-sdk-dynamodb', version.ref = 'aws-sdk' }
 aws-sdk2-core = { group = 'software.amazon.awssdk', name = 'sdk-core', version.ref = 'aws-sdk2' }
 aws-sdk2-dynamo = { group = 'software.amazon.awssdk', name = 'dynamodb', version.ref = 'aws-sdk2' }
+aws-sdk2-dynamodbenhanced = { group = 'software.amazon.awssdk', name = 'dynamodb-enhanced', version.ref = 'aws-sdk2' }
 aws-sdk2-eventbridge = { group = 'software.amazon.awssdk', name = 'eventbridge', version.ref = 'aws-sdk2' }
 aws-sdk2-firehose = { group = 'software.amazon.awssdk', name = 'firehose', version.ref = 'aws-sdk2' }
 aws-sdk2-s3 = { group = 'software.amazon.awssdk', name = 's3', version.ref = 'aws-sdk2' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,8 +53,11 @@ aws-sdk2-dynamo = { group = 'software.amazon.awssdk', name = 'dynamodb', version
 aws-sdk2-dynamodbenhanced = { group = 'software.amazon.awssdk', name = 'dynamodb-enhanced', version.ref = 'aws-sdk2' }
 aws-sdk2-eventbridge = { group = 'software.amazon.awssdk', name = 'eventbridge', version.ref = 'aws-sdk2' }
 aws-sdk2-firehose = { group = 'software.amazon.awssdk', name = 'firehose', version.ref = 'aws-sdk2' }
+aws-sdk2-regions = { group = 'software.amazon.awssdk', name = 'regions', version.ref = 'aws-sdk2' }
 aws-sdk2-s3 = { group = 'software.amazon.awssdk', name = 's3', version.ref = 'aws-sdk2' }
 aws-sdk2-secrets = { group = 'software.amazon.awssdk', name = 'secretsmanager', version.ref = 'aws-sdk2' }
+aws-sdk2-sns = { group = 'software.amazon.awssdk', name = 'sns', version.ref = 'aws-sdk2' }
+aws-sdk2-sqs = { group = 'software.amazon.awssdk', name = 'sqs', version.ref = 'aws-sdk2' }
 aws-sdk2-urlconnection = { group = 'software.amazon.awssdk', name = 'url-connection-client', version.ref = 'aws-sdk2' }
 com-auth0-jwks = { group = 'com.auth0', name = 'jwks-rsa', version.ref = 'com-auth0-jwks' }
 com-auth0-jwt = { group = 'com.auth0', name = 'java-jwt', version.ref = 'com-auth0-jwt' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -105,6 +105,7 @@ junit-jupiter-api = { group = 'org.junit.jupiter', name = 'junit-jupiter-api', v
 junit-jupiter-engine = { group = 'org.junit.jupiter', name = 'junit-jupiter-engine', version.ref = 'jupiter' }
 junit-jupiter-params = { group = 'org.junit.jupiter', name = 'junit-jupiter-params', version.ref = 'jupiter' }
 junit-platform-launcher = { group = 'org.junit.platform', name = 'junit-platform-launcher', version.ref = 'jupiter-platform' }
+junit-platform-suite = { group = 'org.junit.platform', name = 'junit-platform-suite', version.ref = 'jupiter-platform' }
 mockito-core = { group = 'org.mockito', name = 'mockito-core', version.ref = 'mockito' }
 opensearch-java = { group = 'org.opensearch.client', name = 'opensearch-java', version.ref = 'opensearch-client' }
 opensearch-rest-client = { group = 'org.opensearch.client', name = 'opensearch-rest-client', version.ref = 'opensearch-client' }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'nva-commons'
+include 'build-logic'
 include 'json'
 include 'logutils'
 include 'core'
@@ -16,6 +17,3 @@ include 'pagination'
 include 'clients'
 include 'dlq'
 include 'versions'
-
-
-

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+dependencyResolutionManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'nva-commons'
 include 'build-logic'
 include 'json'

--- a/versions/build.gradle
+++ b/versions/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'version-catalog'
+    id 'nvacommons.java-conventions'
     id 'nvacommons.publish-artifact'
 }
 


### PR DESCRIPTION
This adds a new sub-project (`build-logic`) containing custom Gradle plugins, which is published to MavenCentral alongside our other artifacts. This is intended to be used by other NVA projects instead of copy/pasting Gradle files.

Changes:

- feat: Add sub-project for published Gradle plugins
- refactor: Move `group` and `version` references to root `gradle.properties`
- fix: Remove duplicate "allProjects" apply of `buildSrc` plugin
- feat: Expands the version catalog with additional libraries used elsewhere


Follow-up tasks to be done later, in separate PRs:

- Add example to https://github.com/BIBSYSDEV/nva-gradle-template demonstrating usage
- Remove overlapping/duplicate code from `./buildSrc` and replace references with the new plugins in `./build-logic`