### PR TITLE
fix: Unsplit lines to fix whitespace issue

### DIFF
--- a/.github/workflows/maven-central.yml
+++ b/.github/workflows/maven-central.yml
@@ -33,8 +33,4 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew \
-          signMavenJavaPublication \
-          :build-logic:publishToSonatype \
-          publishToSonatype \
-          closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew signMavenJavaPublication :build-logic:publishToSonatype publishToSonatype closeAndReleaseSonatypeStagingRepository


### PR DESCRIPTION
Hopefully fixes this:

```log
FAILURE: Build failed with an exception.

* What went wrong:
Task ' signMavenJavaPublication' not found in root project 'nva-commons' and its subprojects. Some candidates are: 'signMavenJavaPublication'.
```