### PR TITLE
fix: Handle signing properly

### DIFF
--- a/.github/workflows/maven-central.yml
+++ b/.github/workflows/maven-central.yml
@@ -34,7 +34,6 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew \
-          signMavenJavaPublication \
           :build-logic:publishToSonatype \
           publishToSonatype \
           closeAndReleaseSonatypeStagingRepository

--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -33,9 +33,9 @@ publishing {
 }
 
 signing {
-    required = isMainBranch()
-    useInMemoryPgpKeys(findProperty('signingKey'),
-            findProperty('signingPassword'))
+    required = { gradle.parent.rootProject.hasProperty("signingKey") }
+    useInMemoryPgpKeys(gradle.parent.rootProject.findProperty('signingKey'),
+            gradle.parent.rootProject.findProperty('signingPassword'))
     sign publishing.publications
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,33 +14,8 @@ allprojects {
     }
 }
 
-// Configure publishing of each sub-project
+// Load method to configure publishing of each sub-project
 apply from: "$rootDir/gradle/shared-publish.gradle"
-subprojects {
-    plugins.withId('maven-publish') {
-        publishing {
-            publications.withType(MavenPublication).configureEach {
-                pom(configureCommonPom)
-            }
-        }
-
-        signing {
-            required = isMainBranch()
-            useInMemoryPgpKeys(findProperty('signingKey'),
-                    findProperty('signingPassword'))
-            sign publishing.publications
-        }
-
-        afterEvaluate {
-            tasks.named('publishToMavenLocal') {
-                dependsOn(gradle.includedBuild('build-logic').task(':publishToMavenLocal'))
-            }
-            tasks.named("publishToSonatype") {
-                dependsOn(gradle.includedBuild("build-logic").task(":publishToSonatype"))
-            }
-        }
-    }
-}
 
 nexusPublishing {
     repositories {

--- a/buildSrc/src/main/groovy/nvacommons.publish-artifact.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.publish-artifact.gradle
@@ -8,27 +8,11 @@ plugins {
  Part of the maven publishing configuration has to be in the root project (nvacommons.root.gradle)
  ************************************ ATTENTION*****************************************************/
 
-def gitBranch() {
-    def branch = ""
-    def proc = "git rev-parse --abbrev-ref HEAD".execute()
-    proc.in.eachLine { line -> branch = line }
-    proc.err.eachLine { line -> println line }
-    proc.waitFor()
-    branch
-}
-
-boolean isMainBranch() {
-    def branch = gitBranch()
-    return ((branch == "master" || branch == "main"))
-}
-
 signing {
-    if (isMainBranch()) {
-        def signingKey = findProperty("signingKey")
-        def signingPassword = findProperty("signingPassword")
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign publishing.publications
-    }
+    required = { project.hasProperty("signingKey") }
+    useInMemoryPgpKeys(findProperty('signingKey'),
+            findProperty('signingPassword'))
+    sign publishing.publications
 }
 
 ext.configureCommonPom = { MavenPom pom ->
@@ -53,5 +37,14 @@ ext.configureCommonPom = { MavenPom pom ->
         connection.set('scm:git:git://github.com/BIBSYSDEV/nva-commons.git')
         developerConnection.set('scm:git:ssh://github.com/BIBSYSDEV/nva-commons.git')
         url.set('https://github.com/BIBSYSDEV/nva-commons/tree/main')
+    }
+}
+
+afterEvaluate {
+    tasks.named('publishToMavenLocal') {
+        dependsOn(gradle.includedBuild('build-logic').task(':publishToMavenLocal'))
+    }
+    tasks.named("publishToSonatype") {
+        dependsOn(gradle.includedBuild("build-logic").task(":publishToSonatype"))
     }
 }

--- a/buildSrc/src/main/groovy/nvacommons.publish-maven.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.publish-maven.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'maven-publish'
-    id 'signing'
+    id 'nvacommons.publish-artifact'
 }
 
 /***********************************ATTENTION*******************************************************
@@ -18,6 +17,7 @@ publishing {
         mavenJava(MavenPublication) {
             artifactId = project.name
             from components.java
+            pom(configureCommonPom)
             versionMapping {
                 usage('java-api') {
                     fromResolutionOf('runtimeClasspath')

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.gradle.warning.mode=all
 
 # Shared group and version number for all artifacts generated in this project
 GROUP=com.github.bibsysdev
-VERSION_NAME=2.3.8
+VERSION_NAME=2.3.9

--- a/gradle/shared-publish.gradle
+++ b/gradle/shared-publish.gradle
@@ -5,22 +5,6 @@
  * IMPORTANT: The consuming build.gradle must apply the 'maven-publish' and 'signing' plugins
  ************************************ ATTENTION*****************************************************/
 
-def gitBranch() {
-    def branch = ""
-    def proc = "git rev-parse --abbrev-ref HEAD".execute()
-    proc.in.eachLine { line -> branch = line }
-    proc.err.eachLine { line -> println line }
-    proc.waitFor()
-    branch
-}
-
-boolean isMainBranch() {
-    def branch = gitBranch()
-    return ((branch == "master" || branch == "main"))
-}
-
-rootProject.ext.isMainBranch = this.&isMainBranch
-
 ext.configureCommonPom = { MavenPom pom ->
     pom.name.set(project.name)
     pom.description.set('A common library for the NVA project')

--- a/versions/build.gradle
+++ b/versions/build.gradle
@@ -1,8 +1,6 @@
 plugins {
     id 'version-catalog'
-    id 'nvacommons.java-conventions'
-    id 'maven-publish'
-    id 'signing'
+    id 'nvacommons.publish-artifact'
 }
 
 catalog {
@@ -16,6 +14,7 @@ publishing {
         create("versionCatalog", MavenPublication)  {
             artifactId = project.name
             from components.versionCatalog
+            pom(configureCommonPom)
         }
     }
 }


### PR DESCRIPTION
Changes:

- fix: Remove `signMavenJavaPublication` from workflow as not all sub-projects contain it by this name, and the correct task is an automatic dependency
- fix: Move `signing` configuration (back) to `buildSrc` plugin so that it is applied correctly
- refactor: Replace `isMainBranch()` check with a check to see if the necessary signing key is available.
  - Note: This means that signing could happen in feat branches, but not with the current workflow setup. The signing and publishing tasks are only triggered in `main`.