### PR TITLE
fix: Reference keys as env vars directly

### DIFF
--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -33,9 +33,9 @@ publishing {
 }
 
 signing {
-    required = { gradle.parent.rootProject.hasProperty("signingKey") }
-    useInMemoryPgpKeys(gradle.parent.rootProject.findProperty('signingKey'),
-            gradle.parent.rootProject.findProperty('signingPassword'))
+    required = { project.hasProperty("signingKey") }
+    useInMemoryPgpKeys(getProperty('signingKey'),
+            getProperty('signingPassword'))
     sign publishing.publications
 }
 


### PR DESCRIPTION
References signing keys directly and not via root project, as they are set as environment variables and available to the `build-logic` project itself.