### PR TITLE
fix: Add Nexus config to build-logic

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,14 +45,6 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew :build-logic:publishToMavenLocal publishToMavenLocal
 
-      - name: Dry-run
-        env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew :build-logic:initializeSonatypeStagingRepository initializeSonatypeStagingRepository closeAndReleaseSonatypeStagingRepository
-
       - name: Publish artifacts
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,6 +45,14 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew :build-logic:publishToMavenLocal publishToMavenLocal
 
+      - name: Dry-run
+        env:
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew :build-logic:initializeSonatypeStagingRepository initializeSonatypeStagingRepository closeAndReleaseSonatypeStagingRepository
+
       - name: Publish artifacts
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:

--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -40,5 +40,15 @@ signing {
 }
 
 nexusPublishing {
-    repositories { sonatype() }
+    repositories {
+        sonatype {
+            username = findProperty("sonatypeUsername")
+            password = findProperty("sonatypePassword")
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
+    }
+
+    clientTimeout = Duration.ofSeconds(600)
+    connectTimeout = Duration.ofSeconds(60)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.gradle.warning.mode=all
 
 # Shared group and version number for all artifacts generated in this project
 GROUP=com.github.bibsysdev
-VERSION_NAME=2.3.10
+VERSION_NAME=2.3.11


### PR DESCRIPTION
Add full copy of Nexus publishing configuration to `build-logic` to hopefully fix issues with publishing.
If this works, the URLs should probably be moved to environment variables or similar.