### PR TITLE
chore: Disable publish for build-logic

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew :build-logic:publishToMavenLocal publishToMavenLocal
+        run: ./gradlew publishToMavenLocal
 
       - name: Publish artifacts
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -52,4 +52,4 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew :build-logic:publishToSonatype publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/buildSrc/src/main/groovy/nvacommons.publish-artifact.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.publish-artifact.gradle
@@ -39,12 +39,3 @@ ext.configureCommonPom = { MavenPom pom ->
         url.set('https://github.com/BIBSYSDEV/nva-commons/tree/main')
     }
 }
-
-afterEvaluate {
-    tasks.named('publishToMavenLocal') {
-        dependsOn(gradle.includedBuild('build-logic').task(':publishToMavenLocal'))
-    }
-    tasks.named("publishToSonatype") {
-        dependsOn(gradle.includedBuild("build-logic").task(":publishToSonatype"))
-    }
-}


### PR DESCRIPTION
Disables publishing of `build-logic` project temporarily to un-break the deployment pipeline.