### PR TITLE
Np 49498 adding remove xml tags method to stringutils

### DIFF
--- a/core/src/main/java/nva/commons/core/StringUtils.java
+++ b/core/src/main/java/nva/commons/core/StringUtils.java
@@ -1,9 +1,27 @@
 package nva.commons.core;
 
 import static java.util.Objects.isNull;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 public final class StringUtils {
 
+    private static final String BASIC_OUTER_XML_TAGS_TEMPLATE = "<naive>%s</naive>";
+    private static final String PATH_TO_TEXT = "//text()";
     public static final String DOUBLE_WHITESPACE = "\\s\\s";
     public static final String WHITESPACES = "\\s+";
     public static final String SPACE = " ";
@@ -86,5 +104,53 @@ public final class StringUtils {
      */
     public static boolean isNotBlank(String string) {
         return !isBlank(string);
+    }
+
+    public static String removeXmlTags(String input) {
+        String output = null;
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newDefaultInstance();
+        try {
+            Document document = createXmlDocumentFromInput(input, documentBuilderFactory);
+            NodeList nodeList = getDocumentNodes(document);
+            output = textWithoutXmlTags(nodeList);
+        } catch (XPathExpressionException | ParserConfigurationException | IOException | SAXException e) {
+            System.out.println(e.getMessage());
+        } finally {
+            if (isNull(output)) {
+                output = input;
+            }
+        }
+        return removeMultipleWhiteSpaces(output).trim();
+    }
+
+    private static String textWithoutXmlTags(NodeList nodeList) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int counter = 0; counter < nodeList.getLength(); counter++) {
+            stringBuilder.append(EMPTY_STRING).append(nodeList.item(counter).getTextContent());
+        }
+        return stringBuilder.toString();
+    }
+
+    private static NodeList getDocumentNodes(Document document) throws XPathExpressionException {
+        XPathFactory xpathFactory = XPathFactory.newDefaultInstance();
+        XPath xpath = xpathFactory.newXPath();
+        XPathExpression expr = xpath.compile(PATH_TO_TEXT);
+        return (NodeList) expr.evaluate(document, XPathConstants.NODESET);
+    }
+
+    private static Document createXmlDocumentFromInput(String input, DocumentBuilderFactory documentBuilderFactory)
+        throws ParserConfigurationException, SAXException, IOException {
+        DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+        try (Reader reader = new StringReader(wrapInXml(input))) {
+            InputSource inputSource = new InputSource(reader);
+            inputSource.setEncoding(StandardCharsets.UTF_8.name());
+            Document document = documentBuilder.parse(inputSource);
+            document.getDocumentElement().normalize();
+            return document;
+        }
+    }
+
+    private static String wrapInXml(String input) {
+        return String.format(BASIC_OUTER_XML_TAGS_TEMPLATE, input);
     }
 }

--- a/core/src/test/java/nva/commons/core/StringUtilsTest.java
+++ b/core/src/test/java/nva/commons/core/StringUtilsTest.java
@@ -136,6 +136,15 @@ public class StringUtilsTest {
         assertThat(actualContent, is(equalTo(sample)));
     }
 
+    @Test
+    void shouldRemoveXmlTagsFromString() {
+        var string = "Territorial expansion of the European Ips species in the 20<sup>th</sup> century - a review";
+        var updatedString = StringUtils.removeXmlTags(string);
+        var expected = "Territorial expansion of the European Ips species in the 20th century - a review";
+
+        assertThat(updatedString, is(equalTo(expected)));
+    }
+
     static Stream<String> blankStrings() {
         return Stream.of(EMPTY_STRING,
             BLANK_STRING,

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.gradle.warning.mode=all
 
 # Shared group and version number for all artifacts generated in this project
 GROUP=com.github.bibsysdev
-VERSION_NAME=2.3.12
+VERSION_NAME=2.3.13


### PR DESCRIPTION
Adding removeXmlTags method to StringUtils in commons. Method is extracted from StringUtils from nva-fetch-doi.
After this pull request is merged, we can remove StringUtils from nva-fetch-doi and use common StringUtils for NVA instead. 