### PR TITLE
docs: Update publishing metadata

### DIFF
--- a/buildSrc/src/main/groovy/nvacommons.publish-artifact.gradle
+++ b/buildSrc/src/main/groovy/nvacommons.publish-artifact.gradle
@@ -22,15 +22,15 @@ ext.configureCommonPom = { MavenPom pom ->
     pom.licenses {
         license {
             name.set('MIT License')
-            url.set('http://www.opensource.org/licenses/mit-license.php')
+            url.set('https://www.opensource.org/licenses/mit-license.php')
         }
     }
     pom.developers {
         developer {
-            name.set('Orestis Gkorgkas')
-            email.set('og@unit.no')
-            organization.set('UNIT')
-            organizationUrl.set('https://www.unit.no/')
+            name.set("NVA Team")
+            email.set("kontakt@sikt.no")
+            organization.set("Sikt")
+            organizationUrl.set("https://sikt.no/")
         }
     }
     pom.scm {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.warning.mode=all
 
 # Shared group and version number for all artifacts generated in this project
 GROUP=com.github.bibsysdev
-VERSION_NAME=2.6.1
+VERSION_NAME=2.6.2
 
 # Allow Gradle to use more memory than the default (needed for buildHealth command)
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m

--- a/gradle/shared-publish.gradle
+++ b/gradle/shared-publish.gradle
@@ -12,7 +12,7 @@ ext.configureCommonPom = { MavenPom pom ->
     pom.licenses {
         license {
             name.set('MIT License')
-            url.set('http://www.opensource.org/licenses/mit-license.php')
+            url.set('https://www.opensource.org/licenses/mit-license.php')
         }
     }
     pom.developers {

--- a/gradle/shared-publish.gradle
+++ b/gradle/shared-publish.gradle
@@ -17,10 +17,10 @@ ext.configureCommonPom = { MavenPom pom ->
     }
     pom.developers {
         developer {
-            name.set('Orestis Gkorgkas')
-            email.set('og@unit.no')
-            organization.set('UNIT')
-            organizationUrl.set('https://www.unit.no/')
+            name.set("NVA Team")
+            email.set("kontakt@sikt.no")
+            organization.set("Sikt")
+            organizationUrl.set("https://sikt.no/")
         }
     }
     pom.scm {


### PR DESCRIPTION
Updates publishing metadata with generic contact details, as discussed. This config is duplicated (probably no longer necessary), but leaving the clean-up of that to a later PR.